### PR TITLE
Update README with plugin location

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Trying To Adult Management Plugin
 
-This plugin integrates with Authorize.Net for payment processing. For development you may place the API credentials in an `authnet-config.php` file at the plugin root or set them as environment variables before WordPress loads:
+This plugin integrates with Authorize.Net for payment processing. The plugin's files live in `app/public/wp-content/plugins/tta-management-plugin` within this repository. For development you may place the API credentials in an `authnet-config.php` file at the plugin root or set them as environment variables before WordPress loads:
 
 ```
 define('TTA_AUTHNET_LOGIN_ID', 'your_login_id');


### PR DESCRIPTION
## Summary
- document location of the plugin within the repository

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: Test directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_686286d256c48320a17d53dde1c89314