### PR TITLE
Add Your Events widget to events list sidebar

### DIFF
--- a/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/templates/events-list-page-template.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/templates/events-list-page-template.php
@@ -145,6 +145,39 @@ $next_url = $next_allowed ? add_query_arg( [ 'cal_year' => $next_year, 'cal_mont
         </div>
         <?php endif; ?>
 
+        <section class="tta-event-section tta-your-events">
+            <h2 class="tta-eventpage-sidebar-heading"><?php esc_html_e( 'Your Events', 'tta' ); ?></h2>
+            <ul class="tta-your-events-list">
+            <?php if ( ! $context['is_logged_in'] ) : ?>
+                <li>
+                    <img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/login.svg' ); ?>" alt="<?php esc_attr_e( 'Login', 'tta' ); ?>">
+                    <div class="tta-event-details-icon-after"><a href="<?php echo esc_url( wp_login_url( get_permalink() ) ); ?>"><?php esc_html_e( 'Login to see info about your events', 'tta' ); ?></a></div>
+                </li>
+            <?php else : ?>
+                <li>
+                    <img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/profile.svg' ); ?>" alt="<?php esc_attr_e( 'Profile', 'tta' ); ?>">
+                    <div class="tta-event-details-icon-after"><a href="<?php echo esc_url( home_url( '/member-dashboard/?tab=profile', 'relative' ) ); ?>" class="tta-dashboard-link" data-tab="profile"><?php esc_html_e( 'Your Profile Info', 'tta' ); ?></a></div>
+                </li>
+                <li>
+                    <img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/upcoming.svg' ); ?>" alt="<?php esc_attr_e( 'Upcoming', 'tta' ); ?>">
+                    <div class="tta-event-details-icon-after"><a href="<?php echo esc_url( home_url( '/member-dashboard/?tab=upcoming', 'relative' ) ); ?>" class="tta-dashboard-link" data-tab="upcoming"><?php esc_html_e( 'Your Upcoming Events', 'tta' ); ?></a></div>
+                </li>
+                <li>
+                    <img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/past.svg' ); ?>" alt="<?php esc_attr_e( 'Past', 'tta' ); ?>">
+                    <div class="tta-event-details-icon-after"><a href="<?php echo esc_url( home_url( '/member-dashboard/?tab=past', 'relative' ) ); ?>" class="tta-dashboard-link" data-tab="past"><?php esc_html_e( 'Your Past Events', 'tta' ); ?></a></div>
+                </li>
+                <li>
+                    <img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/billing.svg' ); ?>" alt="<?php esc_attr_e( 'Billing', 'tta' ); ?>">
+                    <div class="tta-event-details-icon-after"><a href="<?php echo esc_url( home_url( '/member-dashboard/?tab=billing', 'relative' ) ); ?>" class="tta-dashboard-link" data-tab="billing"><?php esc_html_e( 'Membership Details', 'tta' ); ?></a></div>
+                </li>
+                <li>
+                    <img class="tta-event-details-icon logout-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/login.svg' ); ?>" alt="<?php esc_attr_e( 'Log out', 'tta' ); ?>">
+                    <div class="tta-event-details-icon-after"><a href="<?php echo esc_url( wp_logout_url( get_permalink() ) ); ?>"><?php esc_html_e( 'Log out', 'tta' ); ?></a></div>
+                </li>
+            <?php endif; ?>
+            </ul>
+        </section>
+
         <div class="tta-membership-perks">
             <h2><?php esc_html_e( 'Membership Perks', 'tta' ); ?></h2>
             <?php

--- a/docs/EventsListPage.md
+++ b/docs/EventsListPage.md
@@ -14,7 +14,11 @@ The layout consists of three columns:
    are highlighted and link to the first event scheduled on that date. Navigation
    happens over AJAX so changing months no longer resets pagination. Above the
    friends box is a **Your Upcoming Events** widget showing events for the logged
-   in member and a **Membership Perks** panel encouraging upgrades.
+   in member. Beneath the “Join Your Friends” thumbnails a new **Your Events**
+   section links to profile information, upcoming and past events, billing, and
+   logout. When visitors are not logged in the section displays a login link.
+   The sidebar still ends with the **Membership Perks** panel encouraging
+   upgrades.
 2. **Center column** – the list of upcoming events ordered by date. Each row links
    to the corresponding Event Page. Event images are constrained with `object-fit: contain`
    and are right aligned. Below each event name a list of key details appears with


### PR DESCRIPTION
## Summary
- show the **Your Events** links in the events list sidebar
- document the new sidebar layout in `EventsListPage.md`

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_686289a1b1dc83208f28d533d98903e9