### PR TITLE
Enhance events list attendee display

### DIFF
--- a/app/public/wp-content/plugins/tta-management-plugin/assets/css/frontend/events-list.css
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/css/frontend/events-list.css
@@ -68,11 +68,32 @@ li.tta-event-list-item > div > a > span:hover{
   flex-wrap: wrap;
   gap: 6px;
 }
+.tta-friend-grid .tta-extra-friend { display:none; }
+.tta-friend-grid.expanded .tta-extra-friend { display:inline-block; }
 .tta-friend-thumb {
   width: 40px;
   height: 40px;
   border-radius: 50%;
   object-fit: cover;
+  cursor: pointer;
+}
+
+.tta-accordion-content {
+  max-height: 200px;
+  overflow: hidden;
+  position: relative;
+  background: #fafafa;
+  padding: 20px;
+  border-radius: 4px;
+  transition: max-height 0.4s ease;
+}
+.tta-accordion-content.expanded {
+  max-height: 2000px;
+}
+.tta-accordion-toggle-image-gallery {
+  display: block;
+  margin: 0.5em auto;
+  padding: 0.5em 1em;
   cursor: pointer;
 }
 

--- a/app/public/wp-content/plugins/tta-management-plugin/assets/js/frontend/event-page.js
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/js/frontend/event-page.js
@@ -16,20 +16,25 @@ jQuery(function($){
 });
 
 jQuery(function($){
-  $('.tta-accordion-toggle-image-gallery').on('click', function(){
-    var $btn  = $(this),
-        $cont = $btn.siblings('.tta-accordion-content'),
-        readMore = 'View Gallery',
-        showLess = 'Show less';
+  $('.tta-accordion-toggle-image-gallery')
+    .each(function(){
+      var txt = $(this).text().trim();
+      $(this).data('readMore', txt || 'View Gallery');
+    })
+    .on('click', function(){
+      var $btn  = $(this),
+          $cont = $btn.siblings('.tta-accordion-content'),
+          readMore = $btn.data('readMore') || 'View Gallery',
+          showLess = 'Show less';
 
-    if ( $cont.hasClass('expanded') ) {
-      $cont.removeClass('expanded');
-      $btn.text( readMore );
-    } else {
-      $cont.addClass('expanded');
-      $btn.text( showLess );
-    }
-  });
+      if ( $cont.hasClass('expanded') ) {
+        $cont.removeClass('expanded');
+        $btn.text( readMore );
+      } else {
+        $cont.addClass('expanded');
+        $btn.text( showLess );
+      }
+    });
 });
 
 

--- a/app/public/wp-content/plugins/tta-management-plugin/assets/js/frontend/events-list-page.js
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/js/frontend/events-list-page.js
@@ -1,6 +1,6 @@
 (function($){
   var headerSelector = '.site-header, .tta-header';
-  var extraOffset    = 260;
+  var extraOffset    = 360;
 
   function getHeaderHeight(){
     return $(headerSelector).first().outerHeight() || 0;
@@ -16,5 +16,25 @@
         }, 600);
       }
     });
+
+    $('.tta-join-friends .tta-accordion-toggle-image-gallery')
+      .each(function(){
+        var txt = $(this).text().trim();
+        $(this).data('readMore', txt || 'View Gallery');
+      })
+      .on('click', function(){
+        var $btn  = $(this),
+            $grid = $btn.siblings('.tta-accordion-content').find('.tta-friend-grid');
+        if(!$grid.length){
+          $grid = $btn.closest('.tta-join-friends').find('.tta-friend-grid');
+        }
+        if($grid.hasClass('expanded')){
+          $grid.removeClass('expanded');
+          $btn.text($btn.data('readMore'));
+        } else {
+          $grid.addClass('expanded');
+          $btn.text('Show less');
+        }
+      });
   });
 })(jQuery);

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/templates/events-list-page-template.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/templates/events-list-page-template.php
@@ -31,9 +31,15 @@ $days_in_month = (int) date( 't', mktime( 0, 0, 0, $month, 1, $year ) );
 $first_wday = (int) date( 'w', mktime( 0, 0, 0, $month, 1, $year ) );
 
 $friend_imgs = [];
+$seen        = [];
 foreach ( $events as $ev ) {
     $profiles = tta_get_event_attendee_profiles( $ev['id'] );
     foreach ( $profiles as $p ) {
+        $key = strtolower( trim( $p['first_name'] . ' ' . $p['last_name'] ) . '|' . $p['img_id'] );
+        if ( isset( $seen[ $key ] ) ) {
+            continue;
+        }
+        $seen[ $key ] = true;
         $friend_imgs[] = [
             'img_id' => intval( $p['img_id'] ),
             'name'   => trim( $p['first_name'] . ' ' . $p['last_name'] ),
@@ -128,23 +134,31 @@ $next_url = $next_allowed ? add_query_arg( [ 'cal_year' => $next_year, 'cal_mont
         </div>
 
         <?php if ( $friend_imgs ) : ?>
-        <div class="tta-join-friends">
-            <h2><?php esc_html_e( 'Join Your Friends', 'tta' ); ?></h2>
-            <p class="tta-join-sub"><?php esc_html_e( 'Members attending upcoming events', 'tta' ); ?></p>
-            <div class="tta-friend-grid">
-                <?php foreach ( $friend_imgs as $f ) : ?>
-                    <?php if ( $f['img_id'] ) : ?>
-                        <?php
-                        $thumb = wp_get_attachment_image( $f['img_id'], 'thumbnail', false, [
-                            'class'     => 'tta-friend-thumb tta-popup-img',
-                            'data-full' => wp_get_attachment_image_url( $f['img_id'], 'large' ),
-                            'alt'       => esc_attr( $f['name'] )
-                        ] );
-                        echo $thumb; ?>
-                    <?php else : ?>
-                        <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/placeholder-profile.svg' ); ?>" class="tta-friend-thumb tta-popup-img" data-full="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/placeholder-profile.svg' ); ?>" alt="<?php echo esc_attr( $f['name'] ); ?>">
-                    <?php endif; ?>
-                <?php endforeach; ?>
+        <div class="tta-join-friends tta-event-image-gallery-accordion">
+            <div class="tta-accordion">
+                <div class="tta-accordion-content">
+                    <h2><?php esc_html_e( 'Join Your Friends', 'tta' ); ?></h2>
+                    <p class="tta-join-sub"><?php esc_html_e( 'Members attending upcoming events', 'tta' ); ?></p>
+                    <div class="tta-friend-grid">
+                        <?php $fi = 0; foreach ( $friend_imgs as $f ) : ?>
+                            <?php $extra = $fi >= 12 ? ' tta-extra-friend' : ''; ?>
+                            <?php if ( $f['img_id'] ) : ?>
+                                <?php
+                                $thumb = wp_get_attachment_image( $f['img_id'], 'thumbnail', false, [
+                                    'class'     => 'tta-friend-thumb tta-popup-img' . $extra,
+                                    'data-full' => wp_get_attachment_image_url( $f['img_id'], 'large' ),
+                                    'alt'       => esc_attr( $f['name'] )
+                                ] );
+                                echo $thumb; ?>
+                            <?php else : ?>
+                                <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/placeholder-profile.svg' ); ?>" class="tta-friend-thumb tta-popup-img<?php echo esc_attr( $extra ); ?>" data-full="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/placeholder-profile.svg' ); ?>" alt="<?php echo esc_attr( $f['name'] ); ?>">
+                            <?php endif; ?>
+                        <?php $fi++; endforeach; ?>
+                    </div>
+                </div>
+                <?php if ( count( $friend_imgs ) > 12 ) : ?>
+                    <button type="button" class="tta-button tta-button-primary tta-accordion-toggle-image-gallery"><?php esc_html_e( 'View All Attendees', 'tta' ); ?></button>
+                <?php endif; ?>
             </div>
         </div>
         <?php endif; ?>

--- a/docs/EventsListPage.md
+++ b/docs/EventsListPage.md
@@ -29,7 +29,7 @@ The layout consists of three columns:
 3. **Right column** – an advertising slot that displays one random ad image from
    the Ads admin page.
 
-Profile thumbnails within the “Join Your Friends” section open a larger version in a simple popup when clicked. The popup is disabled on very small screens.
+Profile thumbnails within the “Join Your Friends” section open a larger version in a simple popup when clicked. Duplicate attendees are filtered out so each member only appears once. The first twelve profiles are shown initially with a **View All Attendees** button to reveal the rest. The popup is disabled on very small screens.
 
 On small screens the columns stack vertically for a mobile‑friendly layout.
 


### PR DESCRIPTION
## Summary
- deduplicate attendee thumbnails on the events list page
- initially show 12 attendee images with a "View All Attendees" toggle
- fix accordion toggle text so it restores the original label
- add styles and JS for the new attendee toggle
- increase login scroll offset
- document updated Join Your Friends section

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6862a16c18008320bf34b44bf8ad2b63