### PR TITLE
Handle unsettled refunds with void transaction

### DIFF
--- a/app/public/wp-content/plugins/tta-management-plugin/includes/ajax/handlers/class-ajax-attendance.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/ajax/handlers/class-ajax-attendance.php
@@ -88,7 +88,13 @@ class TTA_Ajax_Attendance {
         $api = new TTA_AuthorizeNet_API();
         $res = $api->refund( $amount, $tx['transaction_id'], $tx['card_last4'] );
         if ( ! $res['success'] ) {
-            wp_send_json_error( [ 'message' => $res['error'] ] );
+            $msg = strtolower( $res['error'] );
+            if ( false !== strpos( $msg, 'not meet the criteria' ) || false !== strpos( $msg, 'not settled' ) ) {
+                $res = $api->void( $tx['transaction_id'] );
+            }
+            if ( ! $res['success'] ) {
+                wp_send_json_error( [ 'message' => $res['error'] ] );
+            }
         }
 
         $wpdb->update(

--- a/docs/AuthorizeNetErrors.md
+++ b/docs/AuthorizeNetErrors.md
@@ -9,5 +9,6 @@ The plugin surfaces Authorize.Net error codes during checkout and refunds. When 
 | `E00003` | The referenced record was not found. | Likely an invalid transaction or customer ID. |
 | `E00007` | User authentication failed. | Verify your sandbox credentials. |
 | `E00027` | The transaction was unsuccessful. | Typically declined by the processor or card issuer. |
+| `54` | The referenced transaction does not meet the criteria for issuing a credit. | Usually indicates the transaction has not settled yet. |
 
 Unknown codes continue to display as-is from Authorize.Net.

--- a/docs/TicketAttendees.md
+++ b/docs/TicketAttendees.md
@@ -10,4 +10,5 @@ admins specify a partial refund before clicking either **Refund & Cancel
 Attendance** or **Refund & Keep Attendance**. The first option both issues the
 refund and removes the attendee from the event while increasing the available
 ticket count. The second option refunds the amount but leaves the attendee
-registered.
+registered. If the transaction has not yet settled, the refund request will
+automatically void the original charge instead.


### PR DESCRIPTION
## Summary
- allow voiding unsettled transactions
- attempt void on refund failure
- document Authorize.Net code 54
- mention voids in attendee documentation

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6862ac3f27f08320a7cc16bead015e73