### PR TITLE
Fix caching after checkout and friend grid

### DIFF
--- a/app/public/wp-content/plugins/tta-management-plugin/assets/css/frontend/events-list.css
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/css/frontend/events-list.css
@@ -87,6 +87,9 @@ li.tta-event-list-item > div > a > span:hover{
   border-radius: 4px;
   transition: max-height 0.4s ease;
 }
+.tta-accordion-content.tta-auto-height {
+  max-height: none;
+}
 .tta-accordion-content.expanded {
   max-height: 2000px;
 }

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/templates/events-list-page-template.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/templates/events-list-page-template.php
@@ -136,7 +136,8 @@ $next_url = $next_allowed ? add_query_arg( [ 'cal_year' => $next_year, 'cal_mont
         <?php if ( $friend_imgs ) : ?>
         <div class="tta-join-friends tta-event-image-gallery-accordion">
             <div class="tta-accordion">
-                <div class="tta-accordion-content">
+                <?php $friend_count = count( $friend_imgs ); ?>
+                <div class="tta-accordion-content<?php echo ( $friend_count <= 12 ) ? ' tta-auto-height' : ''; ?>">
                     <h2><?php esc_html_e( 'Join Your Friends', 'tta' ); ?></h2>
                     <p class="tta-join-sub"><?php esc_html_e( 'Members attending upcoming events', 'tta' ); ?></p>
                     <div class="tta-friend-grid">
@@ -156,7 +157,7 @@ $next_url = $next_allowed ? add_query_arg( [ 'cal_year' => $next_year, 'cal_mont
                         <?php $fi++; endforeach; ?>
                     </div>
                 </div>
-                <?php if ( count( $friend_imgs ) > 12 ) : ?>
+                <?php if ( $friend_count > 12 ) : ?>
                     <button type="button" class="tta-button tta-button-primary tta-accordion-toggle-image-gallery"><?php esc_html_e( 'View All Attendees', 'tta' ); ?></button>
                 <?php endif; ?>
             </div>

--- a/app/public/wp-content/plugins/tta-management-plugin/trying-to-adult-management-plugin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/trying-to-adult-management-plugin.php
@@ -154,6 +154,9 @@ class TTA_Plugin {
         // Expired cart cleanup
         TTA_Cart_Cleanup::init();
         TTA_Event_Archiver::init();
+
+        // Clear plugin caches after a successful checkout
+        add_action( 'tta_checkout_complete', [ 'TTA_Cache', 'flush' ] );
     }
 }
 ?>

--- a/docs/EventsListPage.md
+++ b/docs/EventsListPage.md
@@ -30,6 +30,7 @@ The layout consists of three columns:
    the Ads admin page.
 
 Profile thumbnails within the “Join Your Friends” section open a larger version in a simple popup when clicked. Duplicate attendees are filtered out so each member only appears once. The first twelve profiles are shown initially with a **View All Attendees** button to reveal the rest. The popup is disabled on very small screens.
+When twelve or fewer profiles are available the box auto-expands so all thumbnails are fully visible without needing the button.
 
 On small screens the columns stack vertically for a mobile‑friendly layout.
 

--- a/docs/ObjectCaching.md
+++ b/docs/ObjectCaching.md
@@ -18,6 +18,7 @@ This document outlines the object caching layer used by the Trying To Adult Mana
 - Member records created or edited by admins also trigger a flush so attendee lists update immediately.
 - This helps prevent confusing situations where an admin edits content but the front‑end still shows old data.
 - Ticket availability changes from cart activity or cleanup delete the affected event's ticket cache so numbers stay current.
+- The checkout process triggers `tta_checkout_complete`, which now calls `TTA_Cache::flush()` so membership upgrades and new purchases appear immediately.
 - `TTA_Cache::flush()` locates all plugin transients and removes them using `delete_transient()` so persistent object caches clear properly.
 - The cache layer is bypassed entirely when viewing the plugin's admin pages so the dashboard always shows the most current data.
 


### PR DESCRIPTION
## Summary
- flush caches automatically whenever checkout completes
- auto-expand small Join Friends grids
- document the new cache clearing behavior
- describe auto-expansion in Events List docs

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6863d86bf7688320b65b58dcbf80ed51