### PR TITLE
Fix waitlist label on events list

### DIFF
--- a/app/public/wp-content/plugins/tta-management-plugin/assets/css/frontend/event-page.css
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/css/frontend/event-page.css
@@ -63,6 +63,14 @@
   text-decoration: none;
   border-radius: 4px;
 }
+.tta-button-secondary {
+  display: inline-block;
+  padding: 10px 20px;
+  background: #555;
+  color: #fff;
+  text-decoration: none;
+  border-radius: 4px;
+}
 
 .tta-event-main #tta-login-message .tta-button-primary {
   margin-right:10px;

--- a/app/public/wp-content/plugins/tta-management-plugin/assets/js/frontend/waitlist.js
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/js/frontend/waitlist.js
@@ -81,4 +81,19 @@ jQuery(function($){
         }, delay);
       });
   });
+
+  $(document).on('click', '#tta-leave-waitlist', function(e){
+    e.preventDefault();
+    var $btn = $(this);
+    $btn.prop('disabled', true);
+    $.post(tta_waitlist.ajax_url, {
+      action: 'tta_leave_waitlist',
+      nonce: tta_waitlist.nonce,
+      event_ute_id: tta_waitlist.eventUte
+    }, function(){
+      window.location.reload();
+    }, 'json').fail(function(){
+      window.location.reload();
+    });
+  });
 });

--- a/app/public/wp-content/plugins/tta-management-plugin/assets/js/frontend/waitlist.js
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/js/frontend/waitlist.js
@@ -8,13 +8,17 @@ jQuery(function($){
     $("#tta-waitlist-overlay").fadeOut(200);
   }
 
-  $(document).on('click', '#tta-join-waitlist', function(e){
+  $(document).on('click', '.tta-join-waitlist', function(e){
     e.preventDefault();
     var d = window.tta_waitlist || {};
+    var ticketId = $(this).data('ticket-id') || 0;
+    var ticketName = $(this).data('ticket-name') || '';
     $('#tta-waitlist-form input[name="first_name"]').val(d.firstName||'');
     $('#tta-waitlist-form input[name="last_name"]').val(d.lastName||'');
     $('#tta-waitlist-form input[name="email"]').val(d.email||'');
     $('#tta-waitlist-form input[name="phone"]').val(d.phone||'');
+    $('#tta-waitlist-form input[name="ticket_id"]').val(ticketId);
+    $('#tta-waitlist-form input[name="ticket_name"]').val(ticketName);
     openWL();
   });
 
@@ -43,8 +47,8 @@ jQuery(function($){
       action: "tta_join_waitlist",
       nonce: tta_waitlist.nonce,
       event_ute_id: tta_waitlist.eventUte,
-      ticket_id: tta_waitlist.ticketId,
-      ticket_name: tta_waitlist.ticketName,
+      ticket_id: $form.find('input[name="ticket_id"]').val(),
+      ticket_name: $form.find('input[name="ticket_name"]').val(),
       event_name: tta_waitlist.eventName,
       first_name: $form.find("input[name=first_name]").val(),
       last_name: $form.find("input[name=last_name]").val(),
@@ -82,14 +86,15 @@ jQuery(function($){
       });
   });
 
-  $(document).on('click', '#tta-leave-waitlist', function(e){
+  $(document).on('click', '.tta-leave-waitlist', function(e){
     e.preventDefault();
     var $btn = $(this);
     $btn.prop('disabled', true);
     $.post(tta_waitlist.ajax_url, {
       action: 'tta_leave_waitlist',
       nonce: tta_waitlist.nonce,
-      event_ute_id: tta_waitlist.eventUte
+      event_ute_id: tta_waitlist.eventUte,
+      ticket_id: $btn.data('ticket-id') || 0
     }, function(){
       window.location.reload();
     }, 'json').fail(function(){

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/ajax/handlers/class-ajax-waitlist.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/ajax/handlers/class-ajax-waitlist.php
@@ -5,6 +5,8 @@ class TTA_Ajax_Waitlist {
     public static function init() {
         add_action( 'wp_ajax_tta_join_waitlist', [ __CLASS__, 'join_waitlist' ] );
         add_action( 'wp_ajax_nopriv_tta_join_waitlist', [ __CLASS__, 'join_waitlist' ] );
+        add_action( 'wp_ajax_tta_leave_waitlist', [ __CLASS__, 'leave_waitlist' ] );
+        add_action( 'wp_ajax_nopriv_tta_leave_waitlist', [ __CLASS__, 'leave_waitlist' ] );
     }
 
     public static function join_waitlist() {
@@ -44,6 +46,32 @@ class TTA_Ajax_Waitlist {
 
         if ( ! $wpdb->insert_id ) {
             wp_send_json_error( [ 'message' => 'db_error' ] );
+        }
+        TTA_Cache::flush();
+        wp_send_json_success();
+    }
+
+    public static function leave_waitlist() {
+        check_ajax_referer( 'tta_frontend_nonce', 'nonce' );
+        if ( ! is_user_logged_in() ) {
+            wp_send_json_error( [ 'message' => 'not_logged_in' ] );
+        }
+        $event_ute = sanitize_text_field( $_POST['event_ute_id'] ?? '' );
+        if ( '' === $event_ute ) {
+            wp_send_json_error( [ 'message' => 'missing_event' ] );
+        }
+        global $wpdb;
+        $table = $wpdb->prefix . 'tta_waitlist';
+        $deleted = $wpdb->delete(
+            $table,
+            [
+                'event_ute_id' => $event_ute,
+                'wp_user_id'   => get_current_user_id(),
+            ],
+            [ '%s', '%d' ]
+        );
+        if ( ! $deleted ) {
+            wp_send_json_error( [ 'message' => 'not_found' ] );
         }
         TTA_Cache::flush();
         wp_send_json_success();

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/ajax/handlers/class-ajax-waitlist.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/ajax/handlers/class-ajax-waitlist.php
@@ -57,7 +57,8 @@ class TTA_Ajax_Waitlist {
             wp_send_json_error( [ 'message' => 'not_logged_in' ] );
         }
         $event_ute = sanitize_text_field( $_POST['event_ute_id'] ?? '' );
-        if ( '' === $event_ute ) {
+        $ticket_id = intval( $_POST['ticket_id'] ?? 0 );
+        if ( '' === $event_ute || ! $ticket_id ) {
             wp_send_json_error( [ 'message' => 'missing_event' ] );
         }
         global $wpdb;
@@ -66,9 +67,10 @@ class TTA_Ajax_Waitlist {
             $table,
             [
                 'event_ute_id' => $event_ute,
+                'ticket_id'    => $ticket_id,
                 'wp_user_id'   => get_current_user_id(),
             ],
-            [ '%s', '%d' ]
+            [ '%s', '%d', '%d' ]
         );
         if ( ! $deleted ) {
             wp_send_json_error( [ 'message' => 'not_found' ] );

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/templates/event-page-template.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/templates/event-page-template.php
@@ -81,6 +81,14 @@ $tickets        = TTA_Cache::remember( 'tickets_' . $event['ute_id'], function()
 }, 600 );
 $ticket_count = count( $tickets );
 
+$first_sold_out_ticket = null;
+foreach ( $tickets as $t ) {
+    if ( intval( $t['ticketlimit'] ) < 1 ) {
+        $first_sold_out_ticket = $t;
+        break;
+    }
+}
+
 // Build a map of quantities for this event from the cart
 foreach ( $cart_items as $it ) {
     if ( isset( $it['event_ute_id'] ) && $it['event_ute_id'] === $event['ute_id'] ) {
@@ -128,16 +136,14 @@ wp_localize_script(
     'tta-waitlist-js',
     'tta_waitlist',
     [
-        'ajax_url'   => admin_url( 'admin-ajax.php' ),
-        'nonce'      => wp_create_nonce( 'tta_frontend_nonce' ),
-        'eventUte'   => $event['ute_id'],
-        'ticketId'   => $event['ticket_id'],
-        'ticketName' => $tickets[0]['ticket_name'] ?? 'General Admission',
-        'eventName'  => $event['name'],
-        'firstName'  => $member_row['first_name'] ?? '',
-        'lastName'   => $member_row['last_name'] ?? '',
-        'email'      => $member_row['email'] ?? '',
-        'phone'      => $member_row['phone'] ?? '',
+        'ajax_url'  => admin_url( 'admin-ajax.php' ),
+        'nonce'     => wp_create_nonce( 'tta_frontend_nonce' ),
+        'eventUte'  => $event['ute_id'],
+        'eventName' => $event['name'],
+        'firstName' => $member_row['first_name'] ?? '',
+        'lastName'  => $member_row['last_name'] ?? '',
+        'email'     => $member_row['email'] ?? '',
+        'phone'     => $member_row['phone'] ?? '',
     ]
 );
 
@@ -311,15 +317,16 @@ if ( $is_archived ) {
 
 if ( $is_logged_in ) {
 
-    // b) Check waitlist membership for this event
-    $count = $wpdb->get_var(
+    // b) Check waitlist membership for this event (per ticket)
+    $waitlist_ticket_ids = $wpdb->get_col(
         $wpdb->prepare(
-            "SELECT COUNT(*) FROM {$wpdb->prefix}tta_waitlist WHERE event_ute_id = %s AND wp_user_id = %d",
+            "SELECT ticket_id FROM {$wpdb->prefix}tta_waitlist WHERE event_ute_id = %s AND wp_user_id = %d",
             $event['ute_id'],
             $current_user_id
         )
     );
-    $is_on_waitlist = intval( $count ) > 0;
+    $waitlist_ticket_ids = array_map( 'intval', $waitlist_ticket_ids );
+    $is_on_waitlist = ! empty( $waitlist_ticket_ids );
     if ( $is_on_waitlist ) {
         $waitlist_disabled = true;
         $waitlist_tooltip  = __( 'You are already on the waitlist for this event.', 'tta' );
@@ -663,11 +670,11 @@ echo '<script type="application/ld+json">' . wp_json_encode( $schema, JSON_UNESC
       <?php if ( ! $is_archived ) : ?>
         <?php if ( $all_sold_out && $has_waitlist ) : ?>
         <div class="tta-tickets-addtocart-button">
-          <button type="button" id="tta-join-waitlist" class="tta-button tta-button-primary<?php echo $waitlist_disabled ? ' tta-disabled tta-tooltip-trigger' : ''; ?>"<?php echo $waitlist_disabled ? ' disabled data-tooltip="' . esc_attr( $waitlist_tooltip ) . '"' : ''; ?>>
+          <button type="button" class="tta-button tta-button-primary tta-join-waitlist<?php echo $waitlist_disabled ? ' tta-disabled tta-tooltip-trigger' : ''; ?>" data-ticket-id="<?php echo esc_attr( $first_sold_out_ticket['id'] ?? 0 ); ?>" data-ticket-name="<?php echo esc_attr( $first_sold_out_ticket['ticket_name'] ?? '' ); ?>"<?php echo $waitlist_disabled ? ' disabled data-tooltip="' . esc_attr( $waitlist_tooltip ) . '"' : ''; ?>>
             <?php esc_html_e( 'Join The Waitlist', 'tta' ); ?>
           </button>
           <?php if ( $is_on_waitlist ) : ?>
-          <button type="button" id="tta-leave-waitlist" class="tta-button tta-button-secondary">
+          <button type="button" class="tta-button tta-button-secondary tta-leave-waitlist" data-ticket-id="<?php echo esc_attr( $first_sold_out_ticket['id'] ?? 0 ); ?>">
             <?php esc_html_e( 'Leave the Waitlist', 'tta' ); ?>
           </button>
           <?php endif; ?>
@@ -837,6 +844,18 @@ echo $form_html . $lost_pw_html;
                 </div>
                 <div class="tta-ticket-notice" aria-live="polite"></div>
               </div>
+              <?php if ( $is_sold_out && $has_waitlist ) : ?>
+              <div class="tta-ticket-waitlist">
+                <button type="button" class="tta-button tta-button-primary tta-join-waitlist<?php echo $waitlist_disabled ? ' tta-disabled tta-tooltip-trigger' : ''; ?>" data-ticket-id="<?php echo esc_attr( $ticket['id'] ); ?>" data-ticket-name="<?php echo esc_attr( $ticket['ticket_name'] ); ?>"<?php echo $waitlist_disabled ? ' disabled data-tooltip="' . esc_attr( $waitlist_tooltip ) . '"' : ''; ?>>
+                  <?php esc_html_e( 'Join The Waitlist', 'tta' ); ?>
+                </button>
+                <?php if ( in_array( intval( $ticket['id'] ), $waitlist_ticket_ids, true ) ) : ?>
+                <button type="button" class="tta-button tta-button-secondary tta-leave-waitlist" data-ticket-id="<?php echo esc_attr( $ticket['id'] ); ?>">
+                  <?php esc_html_e( 'Leave the Waitlist', 'tta' ); ?>
+                </button>
+                <?php endif; ?>
+              </div>
+              <?php endif; ?>
             </div>
           <?php endforeach; ?>
         <?php else : ?>
@@ -845,11 +864,11 @@ echo $form_html . $lost_pw_html;
 
         <?php if ( $all_sold_out && $has_waitlist ) : ?>
         <div class="tta-tickets-addtocart-button">
-          <button type="button" id="tta-join-waitlist" class="tta-button tta-button-primary<?php echo $waitlist_disabled ? ' tta-disabled tta-tooltip-trigger' : ''; ?>"<?php echo $waitlist_disabled ? ' disabled data-tooltip="' . esc_attr( $waitlist_tooltip ) . '"' : ''; ?>>
+          <button type="button" class="tta-button tta-button-primary tta-join-waitlist<?php echo $waitlist_disabled ? ' tta-disabled tta-tooltip-trigger' : ''; ?>" data-ticket-id="<?php echo esc_attr( $first_sold_out_ticket['id'] ?? 0 ); ?>" data-ticket-name="<?php echo esc_attr( $first_sold_out_ticket['ticket_name'] ?? '' ); ?>"<?php echo $waitlist_disabled ? ' disabled data-tooltip="' . esc_attr( $waitlist_tooltip ) . '"' : ''; ?>>
             <?php esc_html_e( 'Join The Waitlist', 'tta' ); ?>
           </button>
           <?php if ( $is_on_waitlist ) : ?>
-          <button type="button" id="tta-leave-waitlist" class="tta-button tta-button-secondary">
+          <button type="button" class="tta-button tta-button-secondary tta-leave-waitlist" data-ticket-id="<?php echo esc_attr( $first_sold_out_ticket['id'] ?? 0 ); ?>">
             <?php esc_html_e( 'Leave the Waitlist', 'tta' ); ?>
           </button>
           <?php endif; ?>
@@ -1009,6 +1028,8 @@ echo $form_html . $lost_pw_html;
         <h2><?php esc_html_e( 'Join The Waitlist', 'tta' ); ?></h2>
         <p class="tta-waitlist-description"><?php esc_html_e( 'We\'ll notify you if a spot opens up.', 'tta' ); ?></p>
         <form id="tta-waitlist-form">
+          <input type="hidden" name="ticket_id" value="">
+          <input type="hidden" name="ticket_name" value="">
           <label><?php esc_html_e( 'First Name', 'tta' ); ?>
             <input type="text" name="first_name" required>
           </label>

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/templates/event-page-template.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/templates/event-page-template.php
@@ -667,28 +667,10 @@ echo '<script type="application/ld+json">' . wp_json_encode( $schema, JSON_UNESC
         </a>
       </div>
 
-      <?php if ( ! $is_archived ) : ?>
-        <?php if ( $all_sold_out && $has_waitlist ) : ?>
-        <div class="tta-tickets-addtocart-button">
-          <button type="button" class="tta-button tta-button-primary tta-join-waitlist<?php echo $waitlist_disabled ? ' tta-disabled tta-tooltip-trigger' : ''; ?>" data-ticket-id="<?php echo esc_attr( $first_sold_out_ticket['id'] ?? 0 ); ?>" data-ticket-name="<?php echo esc_attr( $first_sold_out_ticket['ticket_name'] ?? '' ); ?>"<?php echo $waitlist_disabled ? ' disabled data-tooltip="' . esc_attr( $waitlist_tooltip ) . '"' : ''; ?>>
-            <?php esc_html_e( 'Join The Waitlist', 'tta' ); ?>
-          </button>
-          <?php if ( $is_on_waitlist ) : ?>
-          <button type="button" class="tta-button tta-button-secondary tta-leave-waitlist" data-ticket-id="<?php echo esc_attr( $first_sold_out_ticket['id'] ?? 0 ); ?>">
-            <?php esc_html_e( 'Leave the Waitlist', 'tta' ); ?>
-          </button>
-          <?php endif; ?>
-          <?php if ( $waitlist_disabled && $show_upgrade_btn ) : ?>
-          <a href="<?php echo esc_url( home_url( '/become-a-member/' ) ); ?>" class="tta-button tta-button-primary tta-upgrade-btn">
-            <?php echo esc_html( $upgrade_label ); ?>
-          </a>
-          <?php endif; ?>
-        </div>
-        <?php else : ?>
+      <?php if ( ! $is_archived && ! $all_sold_out ) : ?>
         <a href="<?php echo $is_logged_in ? '#tta-event-buy' : '#tta-login-message'; ?>" class="tta-button tta-button-primary<?php echo $is_logged_in ? '' : ' tta-scroll-login'; ?>">
           <?php echo $is_logged_in ? esc_html__( 'Buy Tickets', 'tta' ) : esc_html__( 'Log in to Buy Tickets', 'tta' ); ?>
         </a>
-        <?php endif; ?>
       <?php endif; ?>
     </div>
     <div class="tta-event-hero-image">
@@ -854,6 +836,11 @@ echo $form_html . $lost_pw_html;
                   <?php esc_html_e( 'Leave the Waitlist', 'tta' ); ?>
                 </button>
                 <?php endif; ?>
+                <?php if ( $waitlist_disabled && $show_upgrade_btn ) : ?>
+                <a href="<?php echo esc_url( home_url( '/become-a-member/' ) ); ?>" class="tta-button tta-button-primary tta-upgrade-btn">
+                  <?php echo esc_html( $upgrade_label ); ?>
+                </a>
+                <?php endif; ?>
               </div>
               <?php endif; ?>
             </div>
@@ -862,23 +849,7 @@ echo $form_html . $lost_pw_html;
           <p><?php esc_html_e( 'No tickets available for this event.', 'tta' ); ?></p>
         <?php endif; ?>
 
-        <?php if ( $all_sold_out && $has_waitlist ) : ?>
-        <div class="tta-tickets-addtocart-button">
-          <button type="button" class="tta-button tta-button-primary tta-join-waitlist<?php echo $waitlist_disabled ? ' tta-disabled tta-tooltip-trigger' : ''; ?>" data-ticket-id="<?php echo esc_attr( $first_sold_out_ticket['id'] ?? 0 ); ?>" data-ticket-name="<?php echo esc_attr( $first_sold_out_ticket['ticket_name'] ?? '' ); ?>"<?php echo $waitlist_disabled ? ' disabled data-tooltip="' . esc_attr( $waitlist_tooltip ) . '"' : ''; ?>>
-            <?php esc_html_e( 'Join The Waitlist', 'tta' ); ?>
-          </button>
-          <?php if ( $is_on_waitlist ) : ?>
-          <button type="button" class="tta-button tta-button-secondary tta-leave-waitlist" data-ticket-id="<?php echo esc_attr( $first_sold_out_ticket['id'] ?? 0 ); ?>">
-            <?php esc_html_e( 'Leave the Waitlist', 'tta' ); ?>
-          </button>
-          <?php endif; ?>
-          <?php if ( $waitlist_disabled && $show_upgrade_btn ) : ?>
-          <a href="<?php echo esc_url( home_url( '/become-a-member/' ) ); ?>" class="tta-button tta-button-primary tta-upgrade-btn">
-            <?php echo esc_html( $upgrade_label ); ?>
-          </a>
-          <?php endif; ?>
-        </div>
-        <?php else : ?>
+        <?php if ( ! $all_sold_out ) : ?>
         <div class="tta-tickets-addtocart-button">
           <button
             type="button"
@@ -888,11 +859,6 @@ echo $form_html . $lost_pw_html;
           >
             <?php echo $all_sold_out ? esc_html__( 'Sold Out', 'tta' ) : esc_html__( 'Get Tickets', 'tta' ); ?>
           </button>
-          <?php if ( $disable_controls && $show_upgrade_btn ) : ?>
-          <a href="<?php echo esc_url( home_url( '/become-a-member/' ) ); ?>" class="tta-button tta-button-primary tta-upgrade-btn">
-            <?php echo esc_html( $upgrade_label ); ?>
-          </a>
-          <?php endif; ?>
         </div>
         <?php endif; ?>
       </section>

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/templates/event-page-template.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/templates/event-page-template.php
@@ -666,6 +666,11 @@ echo '<script type="application/ld+json">' . wp_json_encode( $schema, JSON_UNESC
           <button type="button" id="tta-join-waitlist" class="tta-button tta-button-primary<?php echo $waitlist_disabled ? ' tta-disabled tta-tooltip-trigger' : ''; ?>"<?php echo $waitlist_disabled ? ' disabled data-tooltip="' . esc_attr( $waitlist_tooltip ) . '"' : ''; ?>>
             <?php esc_html_e( 'Join The Waitlist', 'tta' ); ?>
           </button>
+          <?php if ( $is_on_waitlist ) : ?>
+          <button type="button" id="tta-leave-waitlist" class="tta-button tta-button-secondary">
+            <?php esc_html_e( 'Leave the Waitlist', 'tta' ); ?>
+          </button>
+          <?php endif; ?>
           <?php if ( $waitlist_disabled && $show_upgrade_btn ) : ?>
           <a href="<?php echo esc_url( home_url( '/become-a-member/' ) ); ?>" class="tta-button tta-button-primary tta-upgrade-btn">
             <?php echo esc_html( $upgrade_label ); ?>
@@ -843,6 +848,11 @@ echo $form_html . $lost_pw_html;
           <button type="button" id="tta-join-waitlist" class="tta-button tta-button-primary<?php echo $waitlist_disabled ? ' tta-disabled tta-tooltip-trigger' : ''; ?>"<?php echo $waitlist_disabled ? ' disabled data-tooltip="' . esc_attr( $waitlist_tooltip ) . '"' : ''; ?>>
             <?php esc_html_e( 'Join The Waitlist', 'tta' ); ?>
           </button>
+          <?php if ( $is_on_waitlist ) : ?>
+          <button type="button" id="tta-leave-waitlist" class="tta-button tta-button-secondary">
+            <?php esc_html_e( 'Leave the Waitlist', 'tta' ); ?>
+          </button>
+          <?php endif; ?>
           <?php if ( $waitlist_disabled && $show_upgrade_btn ) : ?>
           <a href="<?php echo esc_url( home_url( '/become-a-member/' ) ); ?>" class="tta-button tta-button-primary tta-upgrade-btn">
             <?php echo esc_html( $upgrade_label ); ?>

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/templates/event-page-template.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/templates/event-page-template.php
@@ -859,6 +859,11 @@ echo $form_html . $lost_pw_html;
           >
             <?php echo $all_sold_out ? esc_html__( 'Sold Out', 'tta' ) : esc_html__( 'Get Tickets', 'tta' ); ?>
           </button>
+          <?php if ( $disable_controls && $show_upgrade_btn ) : ?>
+          <a href="<?php echo esc_url( home_url( '/become-a-member/' ) ); ?>" class="tta-button tta-button-primary tta-upgrade-btn">
+            <?php echo esc_html( $upgrade_label ); ?>
+          </a>
+          <?php endif; ?>
         </div>
         <?php endif; ?>
       </section>

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
@@ -1851,6 +1851,7 @@ function tta_get_upcoming_events( $paged = 1, $per_page = 5 ) {
             'all_day_event' => ! empty( $row['all_day_event'] ),
             'venuename'     => sanitize_text_field( $row['venuename'] ),
             'address'       => sanitize_text_field( $row['address'] ),
+            'waitlistavailable' => ! empty( $row['waitlistavailable'] ),
             'page_id'       => intval( $row['page_id'] ),
             'mainimageid'   => intval( $row['mainimageid'] ),
         ];

--- a/app/public/wp-content/plugins/tta-management-plugin/tests/CartTest.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/tests/CartTest.php
@@ -68,6 +68,8 @@ class CartTest extends TestCase {
         if (!function_exists('esc_html__')) { function esc_html__($s,$d=null){ return $s; } }
         if (!function_exists('esc_attr')) { function esc_attr($v){ return $v; } }
         if (!function_exists('esc_url')) { function esc_url($v){ return $v; } }
+        if (!function_exists('add_action')) { function add_action($t,$c){} }
+        if (!function_exists('add_filter')) { function add_filter($t,$c,$p=10,$a=1){} }
         if (!function_exists('esc_attr__')) { function esc_attr__($s,$d=null){ return $s; } }
         global $wpdb;
         $wpdb = new DummyWpdbCartHelper();

--- a/app/public/wp-content/plugins/tta-management-plugin/tests/HelpersTest.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/tests/HelpersTest.php
@@ -338,6 +338,35 @@ class HelpersTest extends TestCase {
         $this->assertStringContainsString('wp_tta_events', $wpdb->last_query);
     }
 
+    public function test_get_upcoming_events_includes_waitlist_flag() {
+        global $wpdb;
+        $wpdb = new class {
+            public $prefix = 'wp_';
+            public $last_query = '';
+            public $rows = [];
+            public function get_results($q, $o = ARRAY_A) { $this->last_query = $q; return $this->rows; }
+            public function get_var($q) { return 1; }
+            public function prepare($q, ...$a) { foreach ($a as $v) { $q = preg_replace('/%s/', $v, $q, 1); $q = preg_replace('/%d/', $v, $q, 1); } return $q; }
+        };
+        $wpdb->rows = [ [
+            'id' => 1,
+            'ute_id' => 'ute1',
+            'name' => 'Soon',
+            'date' => '2030-01-01',
+            'time' => '10:00|12:00',
+            'all_day_event' => 0,
+            'venuename' => 'Venue',
+            'address' => '1 St -  - Town - ST - 00000',
+            'page_id' => 5,
+            'mainimageid' => 0,
+            'waitlistavailable' => 1,
+        ] ];
+        require_once __DIR__ . '/../includes/helpers.php';
+        require_once __DIR__ . '/../includes/classes/class-tta-cache.php';
+        $res = tta_get_upcoming_events(1, 5);
+        $this->assertTrue($res['events'][0]['waitlistavailable']);
+    }
+
     public function test_get_event_days_for_month() {
         global $wpdb;
         $wpdb = new class {

--- a/docs/EventPage.md
+++ b/docs/EventPage.md
@@ -38,8 +38,11 @@ The **Event Details** sidebar now lists the event type (Open Event, Basic Member
 When all tickets are sold out but a waitlist is available, the **Join The Waitlist** button appears in the hero area and above the ticket section. Clicking it opens a modal form with first name, last name, email and phone fields plus two consent checkboxes that are pre-selected. Logged‑in members see their info pre-filled. A spinner shows while the form submits and the confirmation message is delayed so the entire process takes at least three seconds. The × close button is black by default and turns white on hover. The modal can be closed by that button or by clicking outside the popup.
 
 Logged-in visitors who are already on a ticket's waitlist see the Join button for that ticket disabled with a tooltip and a new **Leave the Waitlist** button beside it. Clicking that second button removes their waitlist entry via AJAX and reloads the page. Waitlists are tracked separately for each ticket so attendees can join or leave specific ticket types.
+If the Join button is disabled because the visitor doesn't meet the membership requirement, an **Upgrade** link appears beside it so they can easily upgrade before joining.
 
 Visitors who do not meet the event's membership requirement—including logged-out guests—still see the Join The Waitlist buttons, but they are disabled with a tooltip explaining why they cannot join.
+
+The standalone **Get Tickets** button below the ticket table only shows when at least one ticket is available. When all tickets are sold out, this call-to-action is omitted and waitlist controls appear on each ticket row instead.
 
 ## Social Sharing
 

--- a/docs/EventPage.md
+++ b/docs/EventPage.md
@@ -31,7 +31,7 @@ The Event Page template includes a **Message Center** block under the “About T
 
 ## Event Type and Ticket Context
 
-The **Event Details** sidebar now lists the event type (Open Event, Basic Membership Required, or Premium Membership Required). A short message under the “Get Your Tickets Now” heading communicates the membership requirement and offers login or upgrade links depending on the visitor’s status. When the **Get Tickets** or **Join The Waitlist** buttons are disabled due to membership requirements, an adjacent **Upgrade** button appears so visitors can quickly navigate to the membership signup page. The button label changes to “Upgrade to Basic” or “Upgrade to Premium” based on the event.
+The **Event Details** sidebar now lists the event type (Open Event, Basic Membership Required, or Premium Membership Required). A short message under the “Get Your Tickets Now” heading communicates the membership requirement and offers login or upgrade links depending on the visitor’s status. When the **Get Tickets** or **Join The Waitlist** buttons are disabled due to membership requirements, an adjacent **Upgrade** button appears so visitors can quickly navigate to the membership signup page. This link now shows beside each ticket’s waitlist control **and** next to the main “Get Tickets” button. The button label changes to “Upgrade to Basic” or “Upgrade to Premium” based on the event.
 
 ## Waitlist Popup
 

--- a/docs/EventPage.md
+++ b/docs/EventPage.md
@@ -37,6 +37,8 @@ The **Event Details** sidebar now lists the event type (Open Event, Basic Member
 
 When all tickets are sold out but a waitlist is available, the **Join The Waitlist** button appears in the hero area and above the ticket section. Clicking it opens a modal form with first name, last name, email and phone fields plus two consent checkboxes that are pre-selected. Logged‑in members see their info pre-filled. A spinner shows while the form submits and the confirmation message is delayed so the entire process takes at least three seconds. The × close button is black by default and turns white on hover. The modal can be closed by that button or by clicking outside the popup.
 
+Logged-in visitors who are already on the waitlist see the Join button disabled with a tooltip and a new **Leave the Waitlist** button beside it. Clicking that second button removes their waitlist entry via AJAX and reloads the page.
+
 Visitors who do not meet the event's membership requirement—including logged-out guests—still see the Join The Waitlist buttons, but they are disabled with a tooltip explaining why they cannot join.
 
 ## Social Sharing

--- a/docs/EventPage.md
+++ b/docs/EventPage.md
@@ -37,7 +37,7 @@ The **Event Details** sidebar now lists the event type (Open Event, Basic Member
 
 When all tickets are sold out but a waitlist is available, the **Join The Waitlist** button appears in the hero area and above the ticket section. Clicking it opens a modal form with first name, last name, email and phone fields plus two consent checkboxes that are pre-selected. Logged‑in members see their info pre-filled. A spinner shows while the form submits and the confirmation message is delayed so the entire process takes at least three seconds. The × close button is black by default and turns white on hover. The modal can be closed by that button or by clicking outside the popup.
 
-Logged-in visitors who are already on the waitlist see the Join button disabled with a tooltip and a new **Leave the Waitlist** button beside it. Clicking that second button removes their waitlist entry via AJAX and reloads the page.
+Logged-in visitors who are already on a ticket's waitlist see the Join button for that ticket disabled with a tooltip and a new **Leave the Waitlist** button beside it. Clicking that second button removes their waitlist entry via AJAX and reloads the page. Waitlists are tracked separately for each ticket so attendees can join or leave specific ticket types.
 
 Visitors who do not meet the event's membership requirement—including logged-out guests—still see the Join The Waitlist buttons, but they are disabled with a tooltip explaining why they cannot join.
 

--- a/docs/EventsListPage.md
+++ b/docs/EventsListPage.md
@@ -27,7 +27,7 @@ The layout consists of three columns:
   distortion. They are right aligned.
    Below each event name a list of key details appears with the same icons used on individual Event Pages.
    When an event sells out the remaining ticket count is replaced with **Sold Out!** in red text.
-   The “Get Your Tickets” button changes to **Join The Waitlist** when a waitlist is available or **Sold Out** when not.
+  The “Get Your Tickets” button changes to **Join The Waitlist** when a waitlist is available or **Sold Out** when not. The underlying event data now includes a `waitlistavailable` flag used to determine this.
 3. **Right column** – an advertising slot that displays one random ad image from
    the Ads admin page.
 

--- a/docs/EventsListPage.md
+++ b/docs/EventsListPage.md
@@ -27,7 +27,7 @@ The layout consists of three columns:
   distortion. They are right aligned.
    Below each event name a list of key details appears with the same icons used on individual Event Pages.
    When an event sells out the remaining ticket count is replaced with **Sold Out!** in red text.
-  The “Get Your Tickets” button changes to **Join The Waitlist** when a waitlist is available or **Sold Out** when not. The underlying event data now includes a `waitlistavailable` flag used to determine this.
+  The “Get Your Tickets” button changes to **Join The Waitlist** when a waitlist is available or **Sold Out** when not. This only happens when all ticket types for the event are sold out. The underlying event data includes a `waitlistavailable` flag used to determine availability.
 3. **Right column** – an advertising slot that displays one random ad image from
    the Ads admin page.
 


### PR DESCRIPTION
## Summary
- expose `waitlistavailable` in `tta_get_upcoming_events`
- document new flag in Events List docs
- test for waitlist flag in upcoming events helper
- stub missing WordPress hooks in CartTest

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_686c121e2c088320b7605636e16cf959