### PR TITLE
Fix waitlist buttons per ticket

### DIFF
--- a/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/templates/event-page-template.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/templates/event-page-template.php
@@ -121,7 +121,6 @@ $is_logged_in     = $context['is_logged_in'];
 $current_user_id  = $context['wp_user_id'];
 $member_row       = $context['member'] ?? [];
 $membership_level = $context['membership_level'];
-$is_on_waitlist   = false;
 $member_history   = [];
 
 // Load waitlist assets with event/user context
@@ -326,11 +325,7 @@ if ( $is_logged_in ) {
         )
     );
     $waitlist_ticket_ids = array_map( 'intval', $waitlist_ticket_ids );
-    $is_on_waitlist = ! empty( $waitlist_ticket_ids );
-    if ( $is_on_waitlist ) {
-        $waitlist_disabled = true;
-        $waitlist_tooltip  = __( 'You are already on the waitlist for this event.', 'tta' );
-    } elseif ( $disable_controls && $waitlist_disabled === false ) {
+    if ( $disable_controls && $waitlist_disabled === false ) {
         // Mirror the ticket purchase restriction
         if ( false !== strpos( $tooltip_message, 'attend this event' ) ) {
             $waitlist_tooltip = str_replace( 'attend this event', 'join the waitlist', $tooltip_message );
@@ -667,9 +662,15 @@ echo '<script type="application/ld+json">' . wp_json_encode( $schema, JSON_UNESC
         </a>
       </div>
 
-      <?php if ( ! $is_archived && ! $all_sold_out ) : ?>
+      <?php if ( ! $is_archived && ( ! $all_sold_out || $has_waitlist ) ) : ?>
         <a href="<?php echo $is_logged_in ? '#tta-event-buy' : '#tta-login-message'; ?>" class="tta-button tta-button-primary<?php echo $is_logged_in ? '' : ' tta-scroll-login'; ?>">
-          <?php echo $is_logged_in ? esc_html__( 'Buy Tickets', 'tta' ) : esc_html__( 'Log in to Buy Tickets', 'tta' ); ?>
+          <?php
+          if ( $all_sold_out && $has_waitlist ) {
+            echo $is_logged_in ? esc_html__( 'Join The Waitlist', 'tta' ) : esc_html__( 'Log in to Join The Waitlist', 'tta' );
+          } else {
+            echo $is_logged_in ? esc_html__( 'Buy Tickets', 'tta' ) : esc_html__( 'Log in to Buy Tickets', 'tta' );
+          }
+          ?>
         </a>
       <?php endif; ?>
     </div>
@@ -827,8 +828,16 @@ echo $form_html . $lost_pw_html;
                 <div class="tta-ticket-notice" aria-live="polite"></div>
               </div>
               <?php if ( $is_sold_out && $has_waitlist ) : ?>
+              <?php
+                $ticket_waitlist_disabled = $waitlist_disabled;
+                $ticket_waitlist_tooltip  = $waitlist_tooltip;
+                if ( in_array( intval( $ticket['id'] ), $waitlist_ticket_ids, true ) ) {
+                    $ticket_waitlist_disabled = true;
+                    $ticket_waitlist_tooltip  = __( 'You are already on the waitlist for this ticket.', 'tta' );
+                }
+              ?>
               <div class="tta-ticket-waitlist">
-                <button type="button" class="tta-button tta-button-primary tta-join-waitlist<?php echo $waitlist_disabled ? ' tta-disabled tta-tooltip-trigger' : ''; ?>" data-ticket-id="<?php echo esc_attr( $ticket['id'] ); ?>" data-ticket-name="<?php echo esc_attr( $ticket['ticket_name'] ); ?>"<?php echo $waitlist_disabled ? ' disabled data-tooltip="' . esc_attr( $waitlist_tooltip ) . '"' : ''; ?>>
+                <button type="button" class="tta-button tta-button-primary tta-join-waitlist<?php echo $ticket_waitlist_disabled ? ' tta-disabled tta-tooltip-trigger' : ''; ?>" data-ticket-id="<?php echo esc_attr( $ticket['id'] ); ?>" data-ticket-name="<?php echo esc_attr( $ticket['ticket_name'] ); ?>"<?php echo $ticket_waitlist_disabled ? ' disabled data-tooltip="' . esc_attr( $ticket_waitlist_tooltip ) . '"' : ''; ?>>
                   <?php esc_html_e( 'Join The Waitlist', 'tta' ); ?>
                 </button>
                 <?php if ( in_array( intval( $ticket['id'] ), $waitlist_ticket_ids, true ) ) : ?>


### PR DESCRIPTION
## Summary
- check waitlist membership without disabling all tickets
- disable the join button only when the user is on that ticket's waitlist
- show the hero waitlist button when all tickets are sold out

## Testing
- `composer install`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_686c2ead213483209be050dbe5b51662