### PR TITLE
Fix waitlist notification after ticket refunds

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ If these constants are not defined, checkout will fail and an admin notice will 
 - [Membership Benefits](docs/MembershipBenefits.md)
 - [Member Dashboard](docs/MemberDashboard.md)
 - [Member History Admin](docs/MemberHistoryAdmin.md)
+- [TTA Refund Requests Admin](docs/RefundRequestsAdmin.md)
 - [Event Check-In Page](docs/EventCheckInAdmin.md)
 - [Venue Administration](docs/VenuesAdmin.md)
 - [Ticket Attendees](docs/TicketAttendees.md)

--- a/app/public/wp-content/plugins/tta-management-plugin/assets/css/backend/admin.css
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/css/backend/admin.css
@@ -541,3 +541,17 @@ form p.submit{
 .tta-bi-legend {font-size:12px; margin-top:10px; padding-top:4px;}
 .tta-bi-legend span{display:inline-block;margin-right:10px;}
 
+
+/* Refund Requests page */
+.tta-refund-request summary {
+  font-weight: 600;
+  color: #1d2327;
+  font-size: 14px;
+  margin-top: 1em;
+  cursor: pointer;
+}
+.tta-refund-details {
+  margin-left: 20px;
+  margin-bottom: 1em;
+}
+

--- a/app/public/wp-content/plugins/tta-management-plugin/assets/js/backend/admin.js
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/js/backend/admin.js
@@ -957,6 +957,9 @@ $(document).on('click', '.tta-remove-waitlist-entry', function(e){
       if(res.success){
         if(mode === 'cancel'){
           $row.remove();
+          alert(res.data && res.data.message ? res.data.message : 'Refund processed');
+          window.location.reload();
+          return;
         }
         alert(res.data && res.data.message ? res.data.message : 'Refund processed');
       }else{

--- a/app/public/wp-content/plugins/tta-management-plugin/assets/js/frontend/member-dashboard.js
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/js/frontend/member-dashboard.js
@@ -291,4 +291,21 @@ jQuery(function($){
       }, delay);
     });
   });
+
+  // Leave waitlist from dashboard
+  $(document).on('click', '.tta-leave-waitlist', function(e){
+    e.preventDefault();
+    var $btn = $(this);
+    $btn.prop('disabled', true);
+    $.post(TTA_MemberDashboard.ajax_url, {
+      action: 'tta_leave_waitlist',
+      nonce: TTA_MemberDashboard.front_nonce,
+      event_ute_id: $btn.data('event'),
+      ticket_id: $btn.data('ticket')
+    }, function(){
+      window.location.reload();
+    }, 'json').fail(function(){
+      window.location.reload();
+    });
+  });
 });

--- a/app/public/wp-content/plugins/tta-management-plugin/assets/js/frontend/member-dashboard.js
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/js/frontend/member-dashboard.js
@@ -217,6 +217,50 @@ jQuery(function($){
     $form.slideToggle(200);
   });
 
+  // Submit refund request
+  $(document).on('click', '.tta-refund-submit', function(e){
+    e.preventDefault();
+    var $btn  = $(this),
+        $form = $btn.closest('.tta-refund-form'),
+        tx    = $btn.data('tx'),
+        reason= $form.find('textarea').val(),
+        eventId = $form.data('event'),
+        $spin = $form.find('.tta-admin-progress-spinner-svg'),
+        $resp = $form.find('.tta-admin-progress-response-p'),
+        start = Date.now();
+
+    $resp.removeClass('updated error').text('');
+    $btn.prop('disabled', true);
+    $spin.show().css({opacity:0}).fadeTo(200,1);
+
+    $.post(TTA_MemberDashboard.ajax_url, {
+      action: 'tta_request_refund',
+      nonce: TTA_MemberDashboard.front_nonce,
+      transaction_id: tx,
+      event_id: eventId,
+      reason: reason
+    }, function(res){
+      var delay = Math.max(0, 5000 - (Date.now()-start));
+      setTimeout(function(){
+        $spin.fadeOut(200);
+        $btn.prop('disabled', false);
+        if(res.success){
+          $resp.addClass('updated').text(res.data.message);
+          setTimeout(function(){ window.location.reload(); }, 1000);
+        }else{
+          $resp.addClass('error').text(res.data.message||'Error');
+        }
+      }, delay);
+    }, 'json').fail(function(){
+      var delay = Math.max(0, 5000 - (Date.now()-start));
+      setTimeout(function(){
+        $spin.fadeOut(200);
+        $btn.prop('disabled', false);
+        $resp.addClass('error').text('Request failed. Please try again.');
+      }, delay);
+    });
+  });
+
   // Cancel membership form
   $(document).on('submit', '#tta-cancel-membership-form', function(e){
     e.preventDefault();

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-ads-admin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-ads-admin.php
@@ -21,7 +21,7 @@ class TTA_Ads_Admin {
             'tta-ads',
             [ $this, 'render_page' ],
             'dashicons-megaphone',
-            11
+            13
         );
     }
 

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-comms-admin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-comms-admin.php
@@ -7,8 +7,8 @@ class TTA_Comms_Admin {
 
     public function register_menu(){
         add_menu_page(
-            'Email & SMS',
-            'Email & SMS',
+            'TTA Email & SMS',
+            'TTA Email & SMS',
             'manage_options',
             'tta-comms',
             [ $this, 'render_page' ],

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-comms-admin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-comms-admin.php
@@ -13,7 +13,7 @@ class TTA_Comms_Admin {
             'tta-comms',
             [ $this, 'render_page' ],
             'dashicons-email-alt',
-            9
+            6
         );
     }
 

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-events-admin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-events-admin.php
@@ -11,8 +11,8 @@ class TTA_Events_Admin {
 
     public function register_menu() {
         add_menu_page(
-            'Events',
-            'Events',
+            'TTA Events',
+            'TTA Events',
             'manage_options',
             'tta-events',
             [ $this, 'render_page' ],

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-members-admin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-members-admin.php
@@ -21,7 +21,7 @@ class TTA_Members_Admin {
             'tta-members',
             [ $this, 'render_list' ],
             'dashicons-groups',
-            6
+            8
         );
     }
 

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-members-admin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-members-admin.php
@@ -15,8 +15,8 @@ class TTA_Members_Admin {
 
     public function register_menu() {
         add_menu_page(
-            'Members',
-            'Members',
+            'TTA Members',
+            'TTA Members',
             'manage_options',
             'tta-members',
             [ $this, 'render_list' ],

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-refund-requests-admin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-refund-requests-admin.php
@@ -18,10 +18,11 @@ class TTA_Refund_Requests_Admin {
                 $event  = esc_html( $r['event_name'] );
                 $url    = $r['event_url'] ? '<a href="' . esc_url( $r['event_url'] ) . '">' . $event . '</a>' : $event;
 
-                echo '<h2 style="margin-top:1.5em;">' . esc_html( date_i18n( 'F j, Y g:i a', strtotime( $r['date'] ) ) ) . ' - ' . $member . '</h2>';
+                echo '<details class="tta-refund-request"><summary>' . esc_html( date_i18n( 'F j, Y g:i a', strtotime( $r['date'] ) ) ) . ' - ' . $member . '</summary>';
+                echo '<div class="tta-refund-details">';
                 echo '<p><strong>' . esc_html__( 'Event:', 'tta' ) . '</strong> ' . $url . '</p>';
                 echo '<p><strong>' . esc_html__( 'Reason:', 'tta' ) . '</strong> ' . esc_html( $r['reason'] ) . '</p>';
-                echo '<p><em>' . sprintf( esc_html__( 'Past refund requests: %d &nbsp;|&nbsp; Cancellations: %d &nbsp;|&nbsp; No-shows: %d', 'tta' ), $summary['refunds'], $summary['cancellations'], $summary['no_show'] ) . '</em></p>';
+                echo '<p><em>' . sprintf( esc_html__( 'Past refund requests: %d&nbsp;|&nbsp; Cancellations: %d &nbsp;|&nbsp; No-shows: %d', 'tta' ), $summary['refunds'], $summary['cancellations'], $summary['no_show'] ) . '</em></p>';
 
                 if ( $attendees ) {
                     echo '<div class="tta-wl-info-wrapper">';
@@ -53,10 +54,7 @@ class TTA_Refund_Requests_Admin {
                         echo '</tr>';
                     }
 
-                    echo '</tbody></table></div>';
-                } else {
-                    echo '<p>' . esc_html__( 'No attendees found.', 'tta' ) . '</p>';
-                }
+                    echo '</tbody></table></div></details>';
             }
         } else {
             echo '<p>' . esc_html__( 'No refund requests found.', 'tta' ) . '</p>';

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-refund-requests-admin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-refund-requests-admin.php
@@ -1,0 +1,28 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+class TTA_Refund_Requests_Admin {
+    public static function get_instance(){ static $inst; return $inst ?: $inst = new self(); }
+    private function __construct(){ add_action('admin_menu',[ $this,'register_menu' ]); }
+    public function register_menu(){
+        add_menu_page('TTA Refund Requests','TTA Refund Requests','manage_options','tta-refund-requests',[ $this,'render_page' ],'dashicons-money-alt',12);
+    }
+    public function render_page(){
+        echo '<div class="wrap"><h1>' . esc_html__( 'Refund Requests', 'tta' ) . '</h1>';
+        $rows = tta_get_refund_requests();
+        if ( $rows ) {
+            echo '<table class="widefat striped"><thead><tr>';
+            echo '<th>' . esc_html__( 'Date', 'tta' ) . '</th><th>' . esc_html__( 'Member', 'tta' ) . '</th><th>' . esc_html__( 'Event', 'tta' ) . '</th><th>' . esc_html__( 'Reason', 'tta' ) . '</th></tr></thead><tbody>';
+            foreach ( $rows as $r ) {
+                $member = esc_html( $r['member_name'] );
+                $event  = esc_html( $r['event_name'] );
+                $url    = $r['event_url'] ? '<a href="'.esc_url( $r['event_url'] ).'">'.$event.'</a>' : $event;
+                echo '<tr><td>' . esc_html( date_i18n( 'F j, Y g:i a', strtotime( $r['date'] ) ) ) . '</td><td>' . $member . '</td><td>' . $url . '</td><td>' . esc_html( $r['reason'] ) . '</td></tr>';
+            }
+            echo '</tbody></table>';
+        } else {
+            echo '<p>' . esc_html__( 'No refund requests found.', 'tta' ) . '</p>';
+        }
+        echo '</div>';
+    }
+}
+TTA_Refund_Requests_Admin::get_instance();

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-refund-requests-admin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-refund-requests-admin.php
@@ -1,12 +1,28 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 class TTA_Refund_Requests_Admin {
-    public static function get_instance(){ static $inst; return $inst ?: $inst = new self(); }
-    private function __construct(){ add_action('admin_menu',[ $this,'register_menu' ]); }
-    public function register_menu(){
-        add_menu_page('TTA Refund Requests','TTA Refund Requests','manage_options','tta-refund-requests',[ $this,'render_page' ],'dashicons-money-alt',9);
+    public static function get_instance() {
+        static $inst;
+        return $inst ?: $inst = new self();
     }
-    public function render_page(){
+
+    private function __construct() {
+        add_action( 'admin_menu', [ $this, 'register_menu' ] );
+    }
+
+    public function register_menu() {
+        add_menu_page(
+            'TTA Refund Requests',
+            'TTA Refund Requests',
+            'manage_options',
+            'tta-refund-requests',
+            [ $this, 'render_page' ],
+            'dashicons-money-alt',
+            9
+        );
+    }
+
+    public function render_page() {
         echo '<div class="wrap"><h1>' . esc_html__( 'Refund Requests', 'tta' ) . '</h1>';
         $rows = tta_get_refund_requests();
         if ( $rows ) {
@@ -55,6 +71,7 @@ class TTA_Refund_Requests_Admin {
                     }
 
                     echo '</tbody></table></div></details>';
+                }
             }
         } else {
             echo '<p>' . esc_html__( 'No refund requests found.', 'tta' ) . '</p>';
@@ -62,4 +79,5 @@ class TTA_Refund_Requests_Admin {
         echo '</div>';
     }
 }
+
 TTA_Refund_Requests_Admin::get_instance();

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-refund-requests-admin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-refund-requests-admin.php
@@ -10,15 +10,54 @@ class TTA_Refund_Requests_Admin {
         echo '<div class="wrap"><h1>' . esc_html__( 'Refund Requests', 'tta' ) . '</h1>';
         $rows = tta_get_refund_requests();
         if ( $rows ) {
-            echo '<table class="widefat striped"><thead><tr>';
-            echo '<th>' . esc_html__( 'Date', 'tta' ) . '</th><th>' . esc_html__( 'Member', 'tta' ) . '</th><th>' . esc_html__( 'Event', 'tta' ) . '</th><th>' . esc_html__( 'Reason', 'tta' ) . '</th></tr></thead><tbody>';
             foreach ( $rows as $r ) {
+                $attendees = tta_get_refund_request_attendees( $r['transaction_id'], $r['event_id'] );
+                $summary   = tta_get_member_history_summary( $r['member_id'] );
+
                 $member = esc_html( $r['member_name'] );
                 $event  = esc_html( $r['event_name'] );
-                $url    = $r['event_url'] ? '<a href="'.esc_url( $r['event_url'] ).'">'.$event.'</a>' : $event;
-                echo '<tr><td>' . esc_html( date_i18n( 'F j, Y g:i a', strtotime( $r['date'] ) ) ) . '</td><td>' . $member . '</td><td>' . $url . '</td><td>' . esc_html( $r['reason'] ) . '</td></tr>';
+                $url    = $r['event_url'] ? '<a href="' . esc_url( $r['event_url'] ) . '">' . $event . '</a>' : $event;
+
+                echo '<h2 style="margin-top:1.5em;">' . esc_html( date_i18n( 'F j, Y g:i a', strtotime( $r['date'] ) ) ) . ' - ' . $member . '</h2>';
+                echo '<p><strong>' . esc_html__( 'Event:', 'tta' ) . '</strong> ' . $url . '</p>';
+                echo '<p><strong>' . esc_html__( 'Reason:', 'tta' ) . '</strong> ' . esc_html( $r['reason'] ) . '</p>';
+                echo '<p><em>' . sprintf( esc_html__( 'Past refund requests: %d &nbsp;|&nbsp; Cancellations: %d &nbsp;|&nbsp; No-shows: %d', 'tta' ), $summary['refunds'], $summary['cancellations'], $summary['no_show'] ) . '</em></p>';
+
+                if ( $attendees ) {
+                    echo '<div class="tta-wl-info-wrapper">';
+                    echo '<table class="tta-wl-info-table"><thead><tr>';
+                    echo '<th><span class="tta-tooltip-icon" data-tooltip="' . esc_attr__( 'Attendee first and last name.', 'tta' ) . '"><img src="' . esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ) . '" alt="?"></span>' . esc_html__( 'Name', 'tta' ) . '</th>';
+                    echo '<th><span class="tta-tooltip-icon" data-tooltip="' . esc_attr__( 'Attendee email address.', 'tta' ) . '"><img src="' . esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ) . '" alt="?"></span>' . esc_html__( 'Email', 'tta' ) . '</th>';
+                    echo '<th><span class="tta-tooltip-icon" data-tooltip="' . esc_attr__( 'Phone number provided at checkout.', 'tta' ) . '"><img src="' . esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ) . '" alt="?"></span>' . esc_html__( 'Phone', 'tta' ) . '</th>';
+                    echo '<th><span class="tta-tooltip-icon" data-tooltip="' . esc_attr__( 'Amount charged for this ticket.', 'tta' ) . '"><img src="' . esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ) . '" alt="?"></span>' . esc_html__( 'Paid', 'tta' ) . '</th>';
+                    echo '<th><span class="tta-tooltip-icon" data-tooltip="' . esc_attr__( 'Specify a partial refund amount.', 'tta' ) . '"><img src="' . esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ) . '" alt="?"></span>' . esc_html__( 'Refund $', 'tta' ) . '</th>';
+                    echo '<th><span class="tta-tooltip-icon" data-tooltip="' . esc_attr__( 'Available actions for the attendee.', 'tta' ) . '"><img src="' . esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ) . '" alt="?"></span>' . esc_html__( 'Actions', 'tta' ) . '</th>';
+                    echo '</tr></thead><tbody>';
+
+                    $tx_row = reset( $attendees );
+                    if ( $tx_row ) {
+                        echo '<tr class="tta-transaction-group"><td colspan="6" style="background:#f9f9f9;font-weight:bold;">' . sprintf( esc_html__( 'Transaction ID %s - %s', 'tta' ), esc_html( $tx_row['gateway_id'] ), esc_html( mysql2date( 'n/j/Y g:i a', $tx_row['created_at'] ) ) ) . '</td></tr>';
+                    }
+
+                    foreach ( $attendees as $a ) {
+                        $paid = $a['amount_paid'] ? sprintf( esc_html__( '$%s', 'tta' ), number_format_i18n( $a['amount_paid'], 2 ) ) : '&ndash;';
+                        echo '<tr data-attendee-id="' . esc_attr( $a['id'] ) . '">';
+                        echo '<td>' . esc_html( trim( $a['first_name'] . ' ' . $a['last_name'] ) ) . '</td>';
+                        echo '<td>' . esc_html( $a['email'] ) . '</td>';
+                        echo '<td>' . esc_html( $a['phone'] ) . '</td>';
+                        echo '<td>' . $paid . '</td>';
+                        echo '<td><input type="number" class="tta-refund-amount" step="0.01" style="width:70px" placeholder="' . esc_attr__( 'Full', 'tta' ) . '"></td>';
+                        echo '<td><button type="button" class="tta-refund-cancel-attendee" data-attendee="' . esc_attr( $a['id'] ) . '">' . esc_html__( 'Refund & Cancel Attendance', 'tta' ) . '</button> ';
+                        echo '<button type="button" class="tta-refund-keep-attendee" data-attendee="' . esc_attr( $a['id'] ) . '">' . esc_html__( 'Refund & Keep Attendance', 'tta' ) . '</button> ';
+                        echo '<button type="button" class="tta-cancel-attendee" data-attendee="' . esc_attr( $a['id'] ) . '">' . esc_html__( 'Cancel Attendance (No Refund)', 'tta' ) . '</button></td>';
+                        echo '</tr>';
+                    }
+
+                    echo '</tbody></table></div>';
+                } else {
+                    echo '<p>' . esc_html__( 'No attendees found.', 'tta' ) . '</p>';
+                }
             }
-            echo '</tbody></table>';
         } else {
             echo '<p>' . esc_html__( 'No refund requests found.', 'tta' ) . '</p>';
         }

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-refund-requests-admin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-refund-requests-admin.php
@@ -70,7 +70,7 @@ class TTA_Refund_Requests_Admin {
                         echo '</tr>';
                     }
 
-                    echo '</tbody></table></div></details>';
+                    echo '</tbody></table></div></div></details>';
                 }
             }
         } else {

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-refund-requests-admin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-refund-requests-admin.php
@@ -4,7 +4,7 @@ class TTA_Refund_Requests_Admin {
     public static function get_instance(){ static $inst; return $inst ?: $inst = new self(); }
     private function __construct(){ add_action('admin_menu',[ $this,'register_menu' ]); }
     public function register_menu(){
-        add_menu_page('TTA Refund Requests','TTA Refund Requests','manage_options','tta-refund-requests',[ $this,'render_page' ],'dashicons-money-alt',12);
+        add_menu_page('TTA Refund Requests','TTA Refund Requests','manage_options','tta-refund-requests',[ $this,'render_page' ],'dashicons-money-alt',9);
     }
     public function render_page(){
         echo '<div class="wrap"><h1>' . esc_html__( 'Refund Requests', 'tta' ) . '</h1>';

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-settings-admin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-settings-admin.php
@@ -21,7 +21,7 @@ class TTA_Settings_Admin {
             'tta-settings',
             [ $this, 'render_page' ],
             'dashicons-admin-generic',
-            20
+            10
         );
     }
 

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-tickets-admin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-tickets-admin.php
@@ -13,7 +13,7 @@ class TTA_Tickets_Admin {
             'tta-tickets',
             [ $this, 'render_page' ],
             'dashicons-tickets',
-            8
+            11
         );
     }
 

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-tickets-admin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-tickets-admin.php
@@ -7,8 +7,8 @@ class TTA_Tickets_Admin {
 
     public function register_menu() {
         add_menu_page(
-            'Tickets',
-            'Tickets',
+            'TTA Tickets',
+            'TTA Tickets',
             'manage_options',
             'tta-tickets',
             [ $this, 'render_page' ],

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-venues-admin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-venues-admin.php
@@ -4,12 +4,12 @@ class TTA_Venues_Admin {
     public static function get_instance(){ static $inst; return $inst ?: $inst = new self(); }
     private function __construct(){ add_action('admin_menu',[ $this,'register_menu' ] ); }
     public function register_menu(){
-        add_menu_page('Venues','Venues','manage_options','tta-venues',[ $this,'render_page' ],'dashicons-location-alt',8);
+        add_menu_page('TTA Venues','TTA Venues','manage_options','tta-venues',[ $this,'render_page' ],'dashicons-location-alt',12);
     }
     public function render_page(){
         $tabs = [ 'create'=>'Add Venue','manage'=>'Manage Venues' ];
         $current = isset($_GET['tab']) && isset($tabs[$_GET['tab']]) ? $_GET['tab'] : 'create';
-        echo '<h1>Venues</h1><h2 class="nav-tab-wrapper">';
+        echo '<h1>TTA Venues</h1><h2 class="nav-tab-wrapper">';
         foreach($tabs as $slug=>$label){
             $class = $current===$slug ? ' nav-tab-active':'';
             $url = esc_url(add_query_arg(['page'=>'tta-venues','tab'=>$slug],admin_url('admin.php')));

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/ajax/class-ajax-handler.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/ajax/class-ajax-handler.php
@@ -19,6 +19,7 @@ require_once TTA_PLUGIN_DIR . 'includes/ajax/handlers/class-ajax-venues.php';
 require_once TTA_PLUGIN_DIR . 'includes/ajax/handlers/class-ajax-authnet-test.php';
 require_once TTA_PLUGIN_DIR . 'includes/ajax/handlers/class-ajax-bi.php';
 require_once TTA_PLUGIN_DIR . 'includes/ajax/handlers/class-ajax-waitlist.php';
+require_once TTA_PLUGIN_DIR . 'includes/ajax/handlers/class-ajax-refund.php';
 
 
 // Initialize them
@@ -37,3 +38,4 @@ TTA_Ajax_Authnet_Test::init();
 TTA_Ajax_Auth::init();
 TTA_Ajax_BI::init();
 TTA_Ajax_Waitlist::init();
+TTA_Ajax_Refund::init();

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/ajax/handlers/class-ajax-attendance.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/ajax/handlers/class-ajax-attendance.php
@@ -102,7 +102,12 @@ class TTA_Ajax_Attendance {
         }
 
         $wpdb->delete( $att_table, [ 'id' => $id ], [ '%d' ] );
+        $should_notify = false;
         if ( $ticket ) {
+            $current = (int) $wpdb->get_var( $wpdb->prepare( "SELECT ticketlimit FROM {$ticket_table} WHERE id = %d", intval( $att['ticket_id'] ) ) );
+            $after   = $current + 1;
+            $should_notify = ( $current <= 0 && $after > 0 );
+
             $wpdb->query( $wpdb->prepare( "UPDATE {$ticket_table} SET ticketlimit = ticketlimit + 1 WHERE id = %d", intval( $att['ticket_id'] ) ) );
             if ( ! empty( $ticket['event_ute_id'] ) ) {
                 TTA_Cache::delete( 'tickets_' . $ticket['event_ute_id'] );
@@ -110,6 +115,11 @@ class TTA_Ajax_Attendance {
         }
 
         TTA_Cache::flush();
+
+        if ( $should_notify ) {
+            tta_notify_waitlist_ticket_available( intval( $att['ticket_id'] ) );
+        }
+
         wp_send_json_success( [ 'message' => __( 'Attendance cancelled.', 'tta' ) ] );
     }
 
@@ -210,11 +220,19 @@ class TTA_Ajax_Attendance {
 
         if ( 'cancel' === $mode ) {
             $wpdb->delete( $att_table, [ 'id' => $id ], [ '%d' ] );
+            $should_notify = false;
             if ( $ticket ) {
+                $current = (int) $wpdb->get_var( $wpdb->prepare( "SELECT ticketlimit FROM {$ticket_table} WHERE id = %d", intval( $att['ticket_id'] ) ) );
+                $after   = $current + 1;
+                $should_notify = ( $current <= 0 && $after > 0 );
+
                 $wpdb->query( $wpdb->prepare( "UPDATE {$ticket_table} SET ticketlimit = ticketlimit + 1 WHERE id = %d", intval( $att['ticket_id'] ) ) );
                 if ( ! empty( $ticket['event_ute_id'] ) ) {
                     TTA_Cache::delete( 'tickets_' . $ticket['event_ute_id'] );
                 }
+            }
+            if ( $should_notify ) {
+                tta_notify_waitlist_ticket_available( intval( $att['ticket_id'] ) );
             }
         }
 

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/ajax/handlers/class-ajax-refund.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/ajax/handlers/class-ajax-refund.php
@@ -1,0 +1,37 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+class TTA_Ajax_Refund {
+    public static function init() {
+        add_action( 'wp_ajax_tta_request_refund', [ __CLASS__, 'request_refund' ] );
+    }
+
+    public static function request_refund() {
+        check_ajax_referer( 'tta_frontend_nonce', 'nonce' );
+        if ( ! is_user_logged_in() ) {
+            wp_send_json_error( [ 'message' => __( 'You must be logged in.', 'tta' ) ] );
+        }
+        $tx_id   = tta_sanitize_text_field( $_POST['transaction_id'] ?? '' );
+        $event_id= intval( $_POST['event_id'] ?? 0 );
+        $reason  = tta_sanitize_textarea_field( $_POST['reason'] ?? '' );
+        if ( ! $tx_id || ! $event_id ) {
+            wp_send_json_error( [ 'message' => 'missing_data' ] );
+        }
+        global $wpdb;
+        $tx_table   = $wpdb->prefix . 'tta_transactions';
+        $hist_table = $wpdb->prefix . 'tta_memberhistory';
+        $member_id  = (int) $wpdb->get_var( $wpdb->prepare( "SELECT member_id FROM {$tx_table} WHERE transaction_id = %s", $tx_id ) );
+        if ( ! $member_id ) {
+            wp_send_json_error( [ 'message' => 'not_found' ] );
+        }
+        $wpdb->insert( $hist_table, [
+            'member_id'   => $member_id,
+            'wpuserid'    => get_current_user_id(),
+            'event_id'    => $event_id,
+            'action_type' => 'refund_request',
+            'action_data' => wp_json_encode( [ 'transaction_id' => $tx_id, 'reason' => $reason ] ),
+        ], [ '%d','%d','%d','%s','%s' ] );
+        TTA_Cache::delete( 'tta_refund_requests' );
+        wp_send_json_success( [ 'message' => __( 'Refund request submitted.', 'tta' ) ] );
+    }
+}
+TTA_Ajax_Refund::init();

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/classes/class-tta-assets.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/classes/class-tta-assets.php
@@ -27,7 +27,7 @@ class TTA_Assets {
      * @param string $hook_suffix The current admin page.
      */
     public static function enqueue_backend_assets( $hook_suffix ) {
-        if ( isset( $_GET['page'] ) && in_array( $_GET['page'], [ 'tta-events','tta-members','tta-tickets','tta-comms','tta-ads','tta-venues' ], true ) ) {
+        if ( isset( $_GET['page'] ) && in_array( $_GET['page'], [ 'tta-events','tta-members','tta-tickets','tta-comms','tta-ads','tta-venues','tta-refund-requests' ], true ) ) {
 
             // 1) Make sure the full TinyMCE / Quicktags / editor CSS are loaded:
             if ( function_exists( 'wp_enqueue_editor' ) ) {

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/class-tta-member-dashboard.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/class-tta-member-dashboard.php
@@ -74,7 +74,8 @@ class TTA_Member_Dashboard {
                 [
                     'ajax_url'     => admin_url( 'admin-ajax.php' ),
                     'update_nonce' => wp_create_nonce( 'tta_member_front_update' ),
-                    'plugin_url'   => TTA_PLUGIN_URL, // ← so JS can load your bin.svg
+                    'front_nonce'  => wp_create_nonce( 'tta_frontend_nonce' ),
+                    'plugin_url'   => TTA_PLUGIN_URL,
                 ]
             );
         }
@@ -143,6 +144,7 @@ class TTA_Member_Dashboard {
               <ul class="tta-dashboard-tabs">
                 <li data-tab="profile" class="active"><?php esc_html_e( 'Profile Info', 'tta' ); ?></li>
                 <li data-tab="upcoming"><?php esc_html_e( 'Your Upcoming Events', 'tta' ); ?></li>
+                <li data-tab="waitlist"><?php esc_html_e( 'Your Waitlist Events', 'tta' ); ?></li>
                 <li data-tab="past"><?php esc_html_e( 'Your Past Events', 'tta' ); ?></li>
                 <li data-tab="billing"><?php esc_html_e( 'Billing & Membership Info', 'tta' ); ?></li>
               </ul>
@@ -153,6 +155,8 @@ class TTA_Member_Dashboard {
               <?php include plugin_dir_path( __FILE__ ) . 'views/tab-profile.php'; ?>
 
               <?php include plugin_dir_path( __FILE__ ) . 'views/tab-upcoming.php'; ?>
+
+              <?php include plugin_dir_path( __FILE__ ) . 'views/tab-waitlist.php'; ?>
 
               <?php include plugin_dir_path( __FILE__ ) . 'views/tab-past-events.php'; ?>
 

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/views/tab-upcoming.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/views/tab-upcoming.php
@@ -44,11 +44,11 @@
           <?php endforeach; ?>
           <div class="tta-refund-wrapper">
             <?php if ( $ev['amount'] > 0 ) : ?>
-              <a href="#" class="tta-refund-link" data-tx="<?php echo esc_attr( $ev['transaction_id'] ); ?>">
-                <?php esc_html_e( 'Request a Refund', 'tta' ); ?>
+              <a href="#" class="tta-refund-link" data-tx="<?php echo esc_attr( $ev['transaction_id'] ); ?>" data-event="<?php echo esc_attr( $ev['event_id'] ); ?>">
+                <?php esc_html_e( 'Cancel Attendance & Request a Refund', 'tta' ); ?>
               </a>
             <?php else : ?>
-              <a href="#" class="tta-cancel-link" data-tx="<?php echo esc_attr( $ev['transaction_id'] ); ?>">
+              <a href="#" class="tta-cancel-link" data-tx="<?php echo esc_attr( $ev['transaction_id'] ); ?>" data-event="<?php echo esc_attr( $ev['event_id'] ); ?>">
                 <?php esc_html_e( 'Cancel Attendance', 'tta' ); ?>
               </a>
             <?php endif; ?>
@@ -59,7 +59,7 @@
               <span class="description"><?php esc_html_e( 'tell us why you\'re requesting a refund', 'tta' ); ?></span>
               <textarea id="refund-<?php echo esc_attr( $ev['transaction_id'] ); ?>" placeholder="<?php esc_attr_e( 'tell us why you\'re requesting a refund', 'tta' ); ?>"></textarea>
               <button type="button" class="tta-refund-submit" data-tx="<?php echo esc_attr( $ev['transaction_id'] ); ?>">
-                <?php esc_html_e( 'Request Refund', 'tta' ); ?>
+                <?php echo $ev['amount'] > 0 ? esc_html__( 'Cancel Attendance & Request a Refund', 'tta' ) : esc_html__( 'Cancel Attendance', 'tta' ); ?>
               </button>
             </form>
           </div>

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/views/tab-upcoming.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/views/tab-upcoming.php
@@ -52,7 +52,7 @@
                 <?php esc_html_e( 'Cancel Attendance', 'tta' ); ?>
               </a>
             <?php endif; ?>
-            <form class="tta-refund-form" data-tx="<?php echo esc_attr( $ev['transaction_id'] ); ?>">
+            <form class="tta-refund-form" data-tx="<?php echo esc_attr( $ev['transaction_id'] ); ?>" data-event="<?php echo esc_attr( $ev['event_id'] ); ?>">
               <label for="refund-<?php echo esc_attr( $ev['transaction_id'] ); ?>">
                 <?php esc_html_e( 'Refund Request Details', 'tta' ); ?>
               </label>
@@ -61,6 +61,10 @@
               <button type="button" class="tta-refund-submit" data-tx="<?php echo esc_attr( $ev['transaction_id'] ); ?>">
                 <?php echo $ev['amount'] > 0 ? esc_html__( 'Cancel Attendance & Request a Refund', 'tta' ) : esc_html__( 'Cancel Attendance', 'tta' ); ?>
               </button>
+              <span class="tta-progress-spinner">
+                <img class="tta-admin-progress-spinner-svg" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/loading.svg' ); ?>" alt="<?php esc_attr_e( 'Loading…', 'tta' ); ?>" />
+              </span>
+              <span class="tta-admin-progress-response"><p class="tta-admin-progress-response-p"></p></span>
             </form>
           </div>
       <?php endforeach; ?>

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/views/tab-waitlist.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/views/tab-waitlist.php
@@ -1,0 +1,42 @@
+<!-- WAITLIST EVENTS -->
+<div id="tab-waitlist" class="tta-dashboard-section" style="display:none;">
+  <h3><?php esc_html_e( 'Your Waitlist Events', 'tta' ); ?></h3>
+  <?php
+  $events = tta_get_member_waitlist_events( get_current_user_id() );
+  if ( $events ) :
+      foreach ( $events as $ev ) :
+          $thumb = '';
+          if ( ! empty( $ev['image_id'] ) ) {
+              $thumb = wp_get_attachment_image( $ev['image_id'], 'medium' );
+          } elseif ( ! empty( $ev['page_id'] ) ) {
+              $thumb = get_the_post_thumbnail( $ev['page_id'], 'medium' );
+          }
+
+          $date_str = date_i18n( get_option( 'date_format' ), strtotime( $ev['date'] ) );
+          $time_str = '';
+          if ( ! empty( $ev['time'] ) ) {
+              $parts     = array_pad( explode( '|', $ev['time'] ), 2, '' );
+              $start_fmt = $parts[0] ? date_i18n( get_option( 'time_format' ), strtotime( $parts[0] ) ) : '';
+              $end_fmt   = $parts[1] ? date_i18n( get_option( 'time_format' ), strtotime( $parts[1] ) ) : '';
+              $time_str  = trim( $start_fmt . ( $end_fmt ? ' – ' . $end_fmt : '' ) );
+          }
+          ?>
+          <div class="tta-upcoming-event">
+            <?php if ( $thumb ) : ?>
+              <div class="tta-upcoming-thumb"><?php echo $thumb; ?></div>
+            <?php endif; ?>
+            <div class="tta-upcoming-info">
+              <h4><a href="<?php echo esc_url( get_permalink( $ev['page_id'] ) ); ?>"><?php echo esc_html( $ev['name'] ); ?></a></h4>
+              <p class="tta-upcoming-date"><?php echo esc_html( $date_str . ( $time_str ? ' – ' . $time_str : '' ) ); ?></p>
+              <p class="tta-upcoming-address"><?php echo esc_html( tta_format_address( $ev['address'] ) ); ?></p>
+              <p><strong><?php echo esc_html( $ev['ticket_name'] ); ?></strong></p>
+              <button type="button" class="tta-leave-waitlist" data-event="<?php echo esc_attr( $ev['event_ute_id'] ); ?>" data-ticket="<?php echo esc_attr( $ev['ticket_id'] ); ?>">
+                <?php esc_html_e( 'Leave the Waitlist', 'tta' ); ?>
+              </button>
+            </div>
+          </div>
+      <?php endforeach; ?>
+  <?php else : ?>
+      <p><?php esc_html_e( 'You are not currently on any waitlists.', 'tta' ); ?></p>
+  <?php endif; ?>
+</div>

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
@@ -1287,6 +1287,59 @@ function tta_get_member_upcoming_events( $wp_user_id ) {
 }
 
 /**
+ * Retrieve waitlist events for a user.
+ *
+ * @param int $wp_user_id WordPress user ID.
+ * @return array[] List of waitlist entries.
+ */
+function tta_get_member_waitlist_events( $wp_user_id ) {
+    $wp_user_id = intval( $wp_user_id );
+    if ( ! $wp_user_id ) {
+        return [];
+    }
+
+    $cache_key = 'waitlist_events_' . $wp_user_id;
+    $cached    = TTA_Cache::get( $cache_key );
+    if ( false !== $cached ) {
+        return $cached;
+    }
+
+    global $wpdb;
+    $waitlist_table = $wpdb->prefix . 'tta_waitlist';
+    $events_table   = $wpdb->prefix . 'tta_events';
+
+    $rows = $wpdb->get_results(
+        $wpdb->prepare(
+            "SELECT w.ticket_id, w.ticket_name, w.event_name, w.event_ute_id, w.added_at, e.id AS event_id, e.page_id, e.mainimageid, e.date, e.time, e.address FROM {$waitlist_table} w JOIN {$events_table} e ON w.event_ute_id = e.ute_id WHERE w.wp_user_id = %d ORDER BY w.added_at ASC",
+            $wp_user_id
+        ),
+        ARRAY_A
+    );
+
+    $events = [];
+    foreach ( $rows as $r ) {
+        $events[] = [
+            'event_id'     => intval( $r['event_id'] ),
+            'event_ute_id' => sanitize_text_field( $r['event_ute_id'] ),
+            'name'         => sanitize_text_field( $r['event_name'] ),
+            'page_id'      => intval( $r['page_id'] ),
+            'image_id'     => intval( $r['mainimageid'] ),
+            'date'         => $r['date'],
+            'time'         => $r['time'],
+            'address'      => sanitize_text_field( $r['address'] ),
+            'ticket_id'    => intval( $r['ticket_id'] ),
+            'ticket_name'  => sanitize_text_field( $r['ticket_name'] ),
+            'added_at'     => $r['added_at'],
+        ];
+    }
+
+    $ttl = empty( $events ) ? 60 : 300;
+    TTA_Cache::set( $cache_key, $events, $ttl );
+
+    return $events;
+}
+
+/**
  * Retrieve past events purchased by a user.
  *
  * @param int $wp_user_id WordPress user ID.
@@ -1633,6 +1686,9 @@ function tta_get_member_billing_history( $wp_user_id ) {
         if ( ! is_array( $data ) ) {
             continue;
         }
+        if ( empty( $data['amount'] ) && ! empty( $data['cancel'] ) ) {
+            continue; // skip cancel without refund
+        }
         $amount  = -floatval( $data['amount'] ?? 0 );
         $eid     = intval( $row['event_id'] );
         $name    = $event_map[ $eid ]['name'] ?? __( 'Refund', 'tta' );
@@ -1680,6 +1736,44 @@ function tta_get_member_billing_history( $wp_user_id ) {
 
     TTA_Cache::set( $cache_key, $history, 300 );
     return $history;
+}
+
+/**
+ * Retrieve all refund requests submitted by members.
+ *
+ * @return array[] List of refund requests.
+ */
+function tta_get_refund_requests() {
+    $cache_key = 'tta_refund_requests';
+    $cached    = TTA_Cache::get( $cache_key );
+    if ( false !== $cached ) {
+        return $cached;
+    }
+
+    global $wpdb;
+    $hist_table   = $wpdb->prefix . 'tta_memberhistory';
+    $members_table= $wpdb->prefix . 'tta_members';
+    $events_table = $wpdb->prefix . 'tta_events';
+
+    $rows = $wpdb->get_results(
+        "SELECT mh.action_date, mh.action_data, mh.event_id, m.first_name, m.last_name, e.name AS event_name, e.page_id FROM {$hist_table} mh JOIN {$members_table} m ON mh.member_id = m.id JOIN {$events_table} e ON mh.event_id = e.id WHERE mh.action_type = 'refund_request' ORDER BY mh.action_date DESC",
+        ARRAY_A
+    );
+
+    $out = [];
+    foreach ( $rows as $r ) {
+        $data = json_decode( $r['action_data'], true );
+        $out[] = [
+            'date'        => $r['action_date'],
+            'member_name' => trim( $r['first_name'] . ' ' . $r['last_name'] ),
+            'event_name'  => sanitize_text_field( $r['event_name'] ),
+            'event_url'   => $r['page_id'] ? get_permalink( $r['page_id'] ) : '',
+            'reason'      => sanitize_text_field( $data['reason'] ?? '' ),
+        ];
+    }
+
+    TTA_Cache::set( $cache_key, $out, 300 );
+    return $out;
 }
 
 /**

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
@@ -1756,7 +1756,7 @@ function tta_get_refund_requests() {
     $events_table = $wpdb->prefix . 'tta_events';
 
     $rows = $wpdb->get_results(
-        "SELECT mh.action_date, mh.action_data, mh.event_id, m.first_name, m.last_name, e.name AS event_name, e.page_id FROM {$hist_table} mh JOIN {$members_table} m ON mh.member_id = m.id JOIN {$events_table} e ON mh.event_id = e.id WHERE mh.action_type = 'refund_request' ORDER BY mh.action_date DESC",
+        "SELECT mh.member_id, mh.action_date, mh.action_data, mh.event_id, m.first_name, m.last_name, e.name AS event_name, e.page_id FROM {$hist_table} mh JOIN {$members_table} m ON mh.member_id = m.id JOIN {$events_table} e ON mh.event_id = e.id WHERE mh.action_type = 'refund_request' ORDER BY mh.action_date DESC",
         ARRAY_A
     );
 
@@ -1765,15 +1765,96 @@ function tta_get_refund_requests() {
         $data = json_decode( $r['action_data'], true );
         $out[] = [
             'date'        => $r['action_date'],
+            'member_id'   => intval( $r['member_id'] ),
             'member_name' => trim( $r['first_name'] . ' ' . $r['last_name'] ),
+            'event_id'    => intval( $r['event_id'] ),
             'event_name'  => sanitize_text_field( $r['event_name'] ),
             'event_url'   => $r['page_id'] ? get_permalink( $r['page_id'] ) : '',
+            'transaction_id' => sanitize_text_field( $data['transaction_id'] ?? '' ),
             'reason'      => sanitize_text_field( $data['reason'] ?? '' ),
         ];
     }
 
     TTA_Cache::set( $cache_key, $out, 300 );
     return $out;
+}
+
+/**
+ * Retrieve attendee details for a specific refund request.
+ *
+ * @param string $gateway_tx_id Gateway transaction ID.
+ * @param int    $event_id      Event ID.
+ * @return array[]
+ */
+function tta_get_refund_request_attendees( $gateway_tx_id, $event_id ) {
+    $gateway_tx_id = sanitize_text_field( $gateway_tx_id );
+    $event_id      = intval( $event_id );
+    if ( '' === $gateway_tx_id || ! $event_id ) {
+        return [];
+    }
+
+    $cache_key = 'refund_attendees_' . md5( $gateway_tx_id . '_' . $event_id );
+    $cached    = TTA_Cache::get( $cache_key );
+    if ( false !== $cached ) {
+        return $cached;
+    }
+
+    global $wpdb;
+    $tx_table       = $wpdb->prefix . 'tta_transactions';
+    $att_table      = $wpdb->prefix . 'tta_attendees';
+    $att_archive    = $wpdb->prefix . 'tta_attendees_archive';
+    $ticket_table   = $wpdb->prefix . 'tta_tickets';
+    $ticket_archive = $wpdb->prefix . 'tta_tickets_archive';
+    $events_table   = $wpdb->prefix . 'tta_events';
+    $archive_table  = $wpdb->prefix . 'tta_events_archive';
+
+    $tx = $wpdb->get_row( $wpdb->prepare( "SELECT id, details, created_at FROM {$tx_table} WHERE transaction_id = %s", $gateway_tx_id ), ARRAY_A );
+    if ( ! $tx ) {
+        TTA_Cache::set( $cache_key, [], 60 );
+        return [];
+    }
+
+    $ute_id = $wpdb->get_var( $wpdb->prepare( "SELECT ute_id FROM {$events_table} WHERE id = %d UNION SELECT ute_id FROM {$archive_table} WHERE id = %d LIMIT 1", $event_id, $event_id ) );
+    if ( ! $ute_id ) {
+        TTA_Cache::set( $cache_key, [], 60 );
+        return [];
+    }
+
+    $sql = "(SELECT a.id, a.ticket_id, a.first_name, a.last_name, a.email, a.phone FROM {$att_table} a JOIN {$ticket_table} t ON a.ticket_id = t.id WHERE a.transaction_id = %d AND t.event_ute_id = %s) UNION ALL (SELECT a.id, a.ticket_id, a.first_name, a.last_name, a.email, a.phone FROM {$att_archive} a JOIN {$ticket_archive} t ON a.ticket_id = t.id WHERE a.transaction_id = %d AND t.event_ute_id = %s) ORDER BY last_name, first_name";
+    $rows = $wpdb->get_results( $wpdb->prepare( $sql, $tx['id'], $ute_id, $tx['id'], $ute_id ), ARRAY_A );
+
+    $details = json_decode( $tx['details'], true );
+    $price_map = [];
+    if ( is_array( $details ) ) {
+        foreach ( $details as $item ) {
+            if ( ( $item['event_ute_id'] ?? '' ) !== $ute_id ) {
+                continue;
+            }
+            $tid   = intval( $item['ticket_id'] ?? 0 );
+            $price = floatval( $item['final_price'] ?? ( $item['price'] ?? 0 ) );
+            $price_map[ $tid ] = $price;
+        }
+    }
+
+    $attendees = [];
+    foreach ( $rows as $r ) {
+        $tid = intval( $r['ticket_id'] );
+        $attendees[] = [
+            'id'          => intval( $r['id'] ),
+            'first_name'  => sanitize_text_field( $r['first_name'] ),
+            'last_name'   => sanitize_text_field( $r['last_name'] ),
+            'email'       => sanitize_email( $r['email'] ),
+            'phone'       => sanitize_text_field( $r['phone'] ),
+            'amount_paid' => $price_map[ $tid ] ?? 0,
+            'gateway_id'  => $gateway_tx_id,
+            'created_at'  => $tx['created_at'],
+        ];
+    }
+
+    $ttl = empty( $attendees ) ? 60 : 300;
+    TTA_Cache::set( $cache_key, $attendees, $ttl );
+
+    return $attendees;
 }
 
 /**

--- a/app/public/wp-content/plugins/tta-management-plugin/tests/HelpersTest.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/tests/HelpersTest.php
@@ -40,6 +40,9 @@ class DummyWpdbHelpers {
         if ( strpos( $query, 'FROM wp_tta_events' ) !== false ) {
             return $this->event_row_data;
         }
+        if ( strpos( $query, 'FROM wp_tta_transactions' ) !== false ) {
+            return [ 'id' => 99, 'details' => json_encode([['event_ute_id'=>'ute1','ticket_id'=>3,'final_price'=>5]]), 'created_at' => '2025-07-01 10:00:00' ];
+        }
         return [
             'wpuserid' => 1,
             'membership_level' => 'premium',
@@ -456,8 +459,9 @@ class HelpersTest extends TestCase {
         $this->wpdb->results_calls = 0;
         $this->wpdb->results_data = [
             [
+                'member_id' => 7,
                 'action_date' => '2025-07-01 10:00:00',
-                'action_data' => json_encode(['reason'=>'Changed plans']),
+                'action_data' => json_encode(['transaction_id'=>'tx99','reason'=>'Changed plans']),
                 'event_id' => 5,
                 'first_name' => 'Ann',
                 'last_name' => 'Bee',
@@ -473,5 +477,38 @@ class HelpersTest extends TestCase {
         $this->assertSame(1, $wpdb->results_calls);
         $cached = tta_get_refund_requests();
         $this->assertSame(1, $wpdb->results_calls);
+    }
+
+    public function test_get_refund_request_attendees_parses_rows() {
+        global $wpdb;
+        $this->wpdb->results_calls = 0;
+        // first query returns transaction row
+        $this->wpdb->row_calls = 0;
+        $this->wpdb->results_data = [
+            [
+                'id' => 55,
+                'ticket_id' => 3,
+                'first_name' => 'Ann',
+                'last_name' => 'Bee',
+                'email' => 'a@example.com',
+                'phone' => '123',
+            ],
+            [
+                'id' => 56,
+                'ticket_id' => 3,
+                'first_name' => 'Carl',
+                'last_name' => 'Dee',
+                'email' => 'c@example.com',
+                'phone' => '555',
+            ]
+        ];
+        $this->wpdb->event_row_data = [ 'ute_id' => 'ute1', 'hosts' => '', 'volunteers' => '' ];
+        $this->wpdb->last_query = '';
+        require_once __DIR__ . '/../includes/helpers.php';
+        require_once __DIR__ . '/../includes/classes/class-tta-cache.php';
+        $attendees = tta_get_refund_request_attendees('tx1', 5);
+        $this->assertCount(2, $attendees);
+        $this->assertSame('Ann', $attendees[0]['first_name']);
+        $this->assertSame('tx1', $attendees[0]['gateway_id']);
     }
 }

--- a/app/public/wp-content/plugins/tta-management-plugin/tests/HelpersTest.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/tests/HelpersTest.php
@@ -423,4 +423,55 @@ class HelpersTest extends TestCase {
         require_once __DIR__ . '/../includes/helpers.php';
         $this->assertSame('6:00 pm - 8:00 pm', tta_format_event_time('18:00|20:00'));
     }
+    public function test_get_member_waitlist_events_returns_entries() {
+        global $wpdb;
+        $this->wpdb->results_calls = 0;
+        $this->wpdb->results_data = [
+            [
+                'ticket_id' => 1,
+                'ticket_name' => 'General',
+                'event_name' => 'Big Event',
+                'event_ute_id' => 'ute1',
+                'added_at' => '2024-01-01 00:00:00',
+                'event_id' => 5,
+                'page_id' => 10,
+                'mainimageid' => 3,
+                'date' => '2030-01-01',
+                'time' => '18:00|20:00',
+                'address' => '1 St -  - City - ST - 12345'
+            ]
+        ];
+        require_once __DIR__ . '/../includes/helpers.php';
+        require_once __DIR__ . '/../includes/classes/class-tta-cache.php';
+        $events = tta_get_member_waitlist_events(1);
+        $this->assertCount(1, $events);
+        $this->assertSame('Big Event', $events[0]['name']);
+        $this->assertSame(1, $wpdb->results_calls);
+        $cached = tta_get_member_waitlist_events(1);
+        $this->assertSame(1, $wpdb->results_calls);
+    }
+
+    public function test_get_refund_requests_returns_rows() {
+        global $wpdb;
+        $this->wpdb->results_calls = 0;
+        $this->wpdb->results_data = [
+            [
+                'action_date' => '2025-07-01 10:00:00',
+                'action_data' => json_encode(['reason'=>'Changed plans']),
+                'event_id' => 5,
+                'first_name' => 'Ann',
+                'last_name' => 'Bee',
+                'event_name' => 'Fun Event',
+                'page_id' => 2
+            ]
+        ];
+        require_once __DIR__ . '/../includes/helpers.php';
+        require_once __DIR__ . '/../includes/classes/class-tta-cache.php';
+        $rows = tta_get_refund_requests();
+        $this->assertCount(1, $rows);
+        $this->assertSame('Ann Bee', $rows[0]['member_name']);
+        $this->assertSame(1, $wpdb->results_calls);
+        $cached = tta_get_refund_requests();
+        $this->assertSame(1, $wpdb->results_calls);
+    }
 }

--- a/app/public/wp-content/plugins/tta-management-plugin/trying-to-adult-management-plugin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/trying-to-adult-management-plugin.php
@@ -102,6 +102,7 @@ require_once TTA_PLUGIN_DIR . 'includes/admin/class-settings-admin.php';
 require_once TTA_PLUGIN_DIR . 'includes/admin/class-comms-admin.php';
 require_once TTA_PLUGIN_DIR . 'includes/admin/class-ads-admin.php';
 require_once TTA_PLUGIN_DIR . 'includes/admin/class-bi-admin.php';
+require_once TTA_PLUGIN_DIR . 'includes/admin/class-refund-requests-admin.php';
 require_once TTA_PLUGIN_DIR . 'includes/shortcodes/class-events-shortcode.php';
 require_once TTA_PLUGIN_DIR . 'includes/shortcodes/class-members-shortcode.php';
 require_once TTA_PLUGIN_DIR . 'includes/frontend/class-tta-member-dashboard.php';

--- a/app/public/wp-content/plugins/tta-management-plugin/trying-to-adult-management-plugin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/trying-to-adult-management-plugin.php
@@ -144,6 +144,7 @@ class TTA_Plugin {
             TTA_Settings_Admin::get_instance();
             TTA_Comms_Admin::get_instance();
             TTA_Ads_Admin::get_instance();
+            TTA_Refund_Requests_Admin::get_instance();
         } else {
             // Frontend shortcodes
             TTA_Events_Shortcode::get_instance();

--- a/docs/MemberDashboard.md
+++ b/docs/MemberDashboard.md
@@ -19,6 +19,7 @@ shows:
 - The total amount paid for the transaction
 - Each ticket purchased with the attendee names and emails
 - A link to request a refund (paid events) or cancel attendance (free events) which reveals a small form
+- Submitting the form shows a spinner and records a `refund_request` entry in `tta_memberhistory`. Administrators can review requests on the **TTA Refund Requests** admin page.
 
 Events are loaded chronologically and the layout supports any number of events.
 Attendee details are pulled from the transaction history and stored in the

--- a/docs/MemberDashboard.md
+++ b/docs/MemberDashboard.md
@@ -1,7 +1,7 @@
 # Member Dashboard
 
 The Member Dashboard is accessible at `/member-dashboard/` via the shortcode `[tta_member_dashboard]`.
-It presents four tabs: **Profile Info**, **Your Upcoming Events**, **Your Past Events**, and **Billing & Membership Info**. Tooltip icons now appear before each field label for quicker context. The tooltip text is displayed instantly on hover using visibility toggles instead of opacity fades. The dashboard's JavaScript and CSS are enqueued whenever the page is viewed so tab switching works even when not logged in.
+It presents five tabs: **Profile Info**, **Your Upcoming Events**, **Your Waitlist Events**, **Your Past Events**, and **Billing & Membership Info**. Tooltip icons now appear before each field label for quicker context. The tooltip text is displayed instantly on hover using visibility toggles instead of opacity fades. The dashboard's JavaScript and CSS are enqueued whenever the page is viewed so tab switching works even when not logged in.
 
 If a member is banned the dashboard displays a prominent notice at the top explaining the ban duration and purchases are blocked until it expires.
 Non-admin users never see the WordPress dashboard. On login the page simply reloads, and any attempt to access `/wp-admin/` redirects back to the front end.

--- a/docs/RefundRequestsAdmin.md
+++ b/docs/RefundRequestsAdmin.md
@@ -1,7 +1,11 @@
 # TTA Refund Requests Page
 
-The **TTA Refund Requests** screen lists all refund requests submitted by members. Each entry displays the date, member name, event, and the reason provided.
+The **TTA Refund Requests** screen lists every refund request submitted by members.
+Each request shows the date, member name, event link and the reason given. Below
+that a full attendee table mirrors the one used on the **Tickets** screen. Admins
+can refund or cancel each attendee directly from this page.
 
-The table updates automatically whenever a member requests a refund from the **Your Upcoming Events** tab of their dashboard. Rows are ordered with the most recent request first.
-
-Navigate to this page from the WordPress admin menu to review and process refund requests as needed.
+For context the member's history summary is displayed, indicating how many times
+they have previously requested refunds, cancelled attendance, or no‑showed. The
+table refreshes automatically whenever a new refund request is submitted from the
+member dashboard.

--- a/docs/RefundRequestsAdmin.md
+++ b/docs/RefundRequestsAdmin.md
@@ -1,0 +1,7 @@
+# TTA Refund Requests Page
+
+The **TTA Refund Requests** screen lists all refund requests submitted by members. Each entry displays the date, member name, event, and the reason provided.
+
+The table updates automatically whenever a member requests a refund from the **Your Upcoming Events** tab of their dashboard. Rows are ordered with the most recent request first.
+
+Navigate to this page from the WordPress admin menu to review and process refund requests as needed.

--- a/docs/RefundRequestsAdmin.md
+++ b/docs/RefundRequestsAdmin.md
@@ -9,3 +9,4 @@ For context the member's history summary is displayed, indicating how many times
 they have previously requested refunds, cancelled attendance, or no‑showed. The
 table refreshes automatically whenever a new refund request is submitted from the
 member dashboard.
+Each refund request is displayed as a collapsible section. Click the summary line to reveal the attendee table and action buttons.

--- a/docs/TicketAttendees.md
+++ b/docs/TicketAttendees.md
@@ -28,3 +28,9 @@ Joined**, followed by an **Actions** column with a Remove button. Entries are
 ordered from oldest to newest so admins can quickly see who has been waiting the
 longest. Removing an entry deletes it immediately via AJAX so another person can
 take the open spot.
+
+When a refund or cancellation increases a sold‑out ticket's remaining count from
+zero to one, the waitlist email sequence is triggered automatically. Premium
+members are notified immediately, Basic members after ten minutes and Free
+members after fifteen. If a higher tier has no entries, lower tiers move up so
+available tickets are offered fairly.

--- a/docs/VenuesAdmin.md
+++ b/docs/VenuesAdmin.md
@@ -1,6 +1,6 @@
 # Venue Administration
 
-The plugin tracks event venues in a dedicated table. Administrators can access **Venues** under the WordPress admin menu. The page mirrors the Events screen with two tabs and the Add Venue form uses the same tooltip layout as the Events editor.
+The plugin tracks event venues in a dedicated table. Administrators can access **TTA Venues** under the WordPress admin menu. The page mirrors the Events screen with two tabs and the Add Venue form uses the same tooltip layout as the Events editor.
 
 - **Add Venue** – create a new venue with name, address components and up to three extra links.
 - **Manage Venues** – list existing venues in a table with inline editing using the same toggle/accordion behaviour as the Events manager.


### PR DESCRIPTION
## Summary
- send `tta_notify_waitlist_ticket_available()` when attendees are cancelled or refunded
- document how cancellations trigger the waitlist email flow

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_686d9e3002208320ac7faed0fe5bc258