### PR TITLE
Fix refund requests markup

### DIFF
--- a/app/public/wp-content/plugins/tta-management-plugin/assets/js/frontend/member-dashboard.js
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/js/frontend/member-dashboard.js
@@ -212,9 +212,8 @@ jQuery(function($){
   // Refund/cancel form toggle
   $(document).on('click', '.tta-refund-link, .tta-cancel-link', function(e){
     e.preventDefault();
-    var tx = $(this).data('tx');
-    var $form = $('.tta-refund-form[data-tx="'+tx+'"]');
-    $form.slideToggle(200);
+    var $wrap = $(this).closest('.tta-refund-wrapper');
+    $wrap.find('.tta-refund-form').slideToggle(200);
   });
 
   // Submit refund request
@@ -223,6 +222,7 @@ jQuery(function($){
     var $btn  = $(this),
         $form = $btn.closest('.tta-refund-form'),
         tx    = $btn.data('tx'),
+        ticket = $btn.data('ticket'),
         reason= $form.find('textarea').val(),
         eventId = $form.data('event'),
         $spin = $form.find('.tta-admin-progress-spinner-svg'),
@@ -238,6 +238,7 @@ jQuery(function($){
       nonce: TTA_MemberDashboard.front_nonce,
       transaction_id: tx,
       event_id: eventId,
+      ticket_id: ticket,
       reason: reason
     }, function(res){
       var delay = Math.max(0, 5000 - (Date.now()-start));

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-refund-requests-admin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-refund-requests-admin.php
@@ -31,35 +31,20 @@ class TTA_Refund_Requests_Admin {
             echo '<th>' . esc_html__( 'Name', 'tta' ) . '</th>';
             echo '<th>' . esc_html__( 'Event', 'tta' ) . '</th>';
             echo '<th>' . esc_html__( 'Paid', 'tta' ) . '</th>';
-            echo '<th>' . esc_html__( 'Actions', 'tta' ) . '</th>';
             echo '</tr></thead><tbody>';
 
             foreach ( $requests as $req ) {
-                $attendees = tta_get_refund_request_attendees( $req['transaction_id'], $req['event_id'], $req['ticket_id'] );
-                if ( ! $attendees ) {
-                    continue;
-                }
-
                 $event_name = esc_html( $req['event_name'] );
                 $event_link = $req['event_url'] ? '<a href="' . esc_url( $req['event_url'] ) . '">' . $event_name . '</a>' : $event_name;
                 $date = esc_html( date_i18n( 'F j, Y g:i a', strtotime( $req['date'] ) ) );
-
-                foreach ( $attendees as $att ) {
-                    $name = esc_html( trim( $att['first_name'] . ' ' . $att['last_name'] ) );
-                    $paid = $att['amount_paid'] ? sprintf( esc_html__( '$%s', 'tta' ), number_format_i18n( $att['amount_paid'], 2 ) ) : '&ndash;';
-                    echo '<tr data-attendee-id="' . esc_attr( $att['id'] ) . '">';
-                    echo '<td>' . $date . '</td>';
-                    echo '<td>' . $name . '</td>';
-                    echo '<td>' . $event_link . '</td>';
-                    echo '<td>' . $paid . '</td>';
-                    echo '<td>';
-                    echo '<input type="number" class="tta-refund-amount" step="0.01" style="width:70px" placeholder="' . esc_attr__( 'Full', 'tta' ) . '"> ';
-                    echo '<button type="button" class="tta-refund-cancel-attendee" data-attendee="' . esc_attr( $att['id'] ) . '">' . esc_html__( 'Refund & Cancel Attendance', 'tta' ) . '</button> ';
-                    echo '<button type="button" class="tta-refund-keep-attendee" data-attendee="' . esc_attr( $att['id'] ) . '">' . esc_html__( 'Refund & Keep Attendance', 'tta' ) . '</button> ';
-                    echo '<button type="button" class="tta-cancel-attendee" data-attendee="' . esc_attr( $att['id'] ) . '">' . esc_html__( 'Cancel Attendance (No Refund)', 'tta' ) . '</button>';
-                    echo '</td>';
-                    echo '</tr>';
-                }
+                $name = esc_html( trim( $req['first_name'] . ' ' . $req['last_name'] ) );
+                $paid = $req['amount_paid'] ? sprintf( esc_html__( '$%s', 'tta' ), number_format_i18n( $req['amount_paid'], 2 ) ) : '&ndash;';
+                echo '<tr>';
+                echo '<td>' . $date . '</td>';
+                echo '<td>' . $name . '</td>';
+                echo '<td>' . $event_link . '</td>';
+                echo '<td>' . $paid . '</td>';
+                echo '</tr>';
             }
 
             echo '</tbody></table>';

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-refund-requests-admin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-refund-requests-admin.php
@@ -35,7 +35,7 @@ class TTA_Refund_Requests_Admin {
             echo '</tr></thead><tbody>';
 
             foreach ( $requests as $req ) {
-                $attendees = tta_get_refund_request_attendees( $req['transaction_id'], $req['event_id'] );
+                $attendees = tta_get_refund_request_attendees( $req['transaction_id'], $req['event_id'], $req['ticket_id'] );
                 if ( ! $attendees ) {
                     continue;
                 }

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-refund-requests-admin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-refund-requests-admin.php
@@ -24,59 +24,40 @@ class TTA_Refund_Requests_Admin {
 
     public function render_page() {
         echo '<div class="wrap"><h1>' . esc_html__( 'Refund Requests', 'tta' ) . '</h1>';
-        $rows = tta_get_refund_requests();
-        if ( $rows ) {
-            foreach ( $rows as $r ) {
-                $attendees = tta_get_refund_request_attendees( $r['transaction_id'], $r['event_id'] );
-                $summary   = tta_get_member_history_summary( $r['member_id'] );
+        $requests = tta_get_refund_requests();
+        if ( $requests ) {
+            echo '<table class="widefat fixed striped"><thead><tr>';
+            echo '<th>' . esc_html__( 'Requested', 'tta' ) . '</th>';
+            echo '<th>' . esc_html__( 'Name', 'tta' ) . '</th>';
+            echo '<th>' . esc_html__( 'Event', 'tta' ) . '</th>';
+            echo '<th>' . esc_html__( 'Paid', 'tta' ) . '</th>';
+            echo '<th>' . esc_html__( 'Actions', 'tta' ) . '</th>';
+            echo '</tr></thead><tbody>';
 
-                $member = esc_html( $r['member_name'] );
-                $event  = esc_html( $r['event_name'] );
-                $url    = $r['event_url'] ? '<a href="' . esc_url( $r['event_url'] ) . '">' . $event . '</a>' : $event;
-
-                echo '<details class="tta-refund-request"><summary>' . esc_html( date_i18n( 'F j, Y g:i a', strtotime( $r['date'] ) ) ) . ' - ' . $member . '</summary>';
-                echo '<div class="tta-refund-details">';
-                echo '<p><strong>' . esc_html__( 'Event:', 'tta' ) . '</strong> ' . $url . '</p>';
-                echo '<p><strong>' . esc_html__( 'Reason:', 'tta' ) . '</strong> ' . esc_html( $r['reason'] ) . '</p>';
-                echo '<p><em>' . sprintf( esc_html__( 'Past refund requests: %d&nbsp;|&nbsp; Cancellations: %d &nbsp;|&nbsp; No-shows: %d', 'tta' ), $summary['refunds'], $summary['cancellations'], $summary['no_show'] ) . '</em></p>';
-
-                if ( $attendees ) {
-                    echo '<div class="tta-wl-info-wrapper">';
-                    echo '<table class="tta-wl-info-table"><thead><tr>';
-                    echo '<th><span class="tta-tooltip-icon" data-tooltip="' . esc_attr__( 'Attendee first and last name.', 'tta' ) . '"><img src="' . esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ) . '" alt="?"></span>' . esc_html__( 'Name', 'tta' ) . '</th>';
-                    echo '<th><span class="tta-tooltip-icon" data-tooltip="' . esc_attr__( 'Attendee email address.', 'tta' ) . '"><img src="' . esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ) . '" alt="?"></span>' . esc_html__( 'Email', 'tta' ) . '</th>';
-                    echo '<th><span class="tta-tooltip-icon" data-tooltip="' . esc_attr__( 'Phone number provided at checkout.', 'tta' ) . '"><img src="' . esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ) . '" alt="?"></span>' . esc_html__( 'Phone', 'tta' ) . '</th>';
-                    echo '<th><span class="tta-tooltip-icon" data-tooltip="' . esc_attr__( 'Amount charged for this ticket.', 'tta' ) . '"><img src="' . esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ) . '" alt="?"></span>' . esc_html__( 'Paid', 'tta' ) . '</th>';
-                    echo '<th><span class="tta-tooltip-icon" data-tooltip="' . esc_attr__( 'Specify a partial refund amount.', 'tta' ) . '"><img src="' . esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ) . '" alt="?"></span>' . esc_html__( 'Refund $', 'tta' ) . '</th>';
-                    echo '<th><span class="tta-tooltip-icon" data-tooltip="' . esc_attr__( 'Available actions for the attendee.', 'tta' ) . '"><img src="' . esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ) . '" alt="?"></span>' . esc_html__( 'Actions', 'tta' ) . '</th>';
-                    echo '</tr></thead><tbody>';
-
-                    $tx_row = reset( $attendees );
-                    if ( $tx_row ) {
-                        echo '<tr class="tta-transaction-group"><td colspan="6" style="background:#f9f9f9;font-weight:bold;">' . sprintf( esc_html__( 'Transaction ID %s - %s', 'tta' ), esc_html( $tx_row['gateway_id'] ), esc_html( mysql2date( 'n/j/Y g:i a', $tx_row['created_at'] ) ) ) . '</td></tr>';
-                    }
-
-                    foreach ( $attendees as $a ) {
-                        $paid = $a['amount_paid'] ? sprintf( esc_html__( '$%s', 'tta' ), number_format_i18n( $a['amount_paid'], 2 ) ) : '&ndash;';
-                        echo '<tr data-attendee-id="' . esc_attr( $a['id'] ) . '">';
-                        echo '<td>' . esc_html( trim( $a['first_name'] . ' ' . $a['last_name'] ) ) . '</td>';
-                        echo '<td>' . esc_html( $a['email'] ) . '</td>';
-                        echo '<td>' . esc_html( $a['phone'] ) . '</td>';
-                        echo '<td>' . $paid . '</td>';
-                        echo '<td><input type="number" class="tta-refund-amount" step="0.01" style="width:70px" placeholder="' . esc_attr__( 'Full', 'tta' ) . '"></td>';
-                        echo '<td><button type="button" class="tta-refund-cancel-attendee" data-attendee="' . esc_attr( $a['id'] ) . '">' . esc_html__( 'Refund & Cancel Attendance', 'tta' ) . '</button> ';
-                        echo '<button type="button" class="tta-refund-keep-attendee" data-attendee="' . esc_attr( $a['id'] ) . '">' . esc_html__( 'Refund & Keep Attendance', 'tta' ) . '</button> ';
-                        echo '<button type="button" class="tta-cancel-attendee" data-attendee="' . esc_attr( $a['id'] ) . '">' . esc_html__( 'Cancel Attendance (No Refund)', 'tta' ) . '</button></td>';
-                        echo '</tr>';
-                    }
-
-                    echo '</tbody></table></div>';
-                } else {
-                    echo '<p>' . esc_html__( 'No attendees found.', 'tta' ) . '</p>';
+            foreach ( $requests as $req ) {
+                $attendees = tta_get_refund_request_attendees( $req['transaction_id'], $req['event_id'] );
+                if ( ! $attendees ) {
+                    continue;
                 }
 
-                echo '</div></details>';
+                $event_name = esc_html( $req['event_name'] );
+                $event_link = $req['event_url'] ? '<a href="' . esc_url( $req['event_url'] ) . '">' . $event_name . '</a>' : $event_name;
+                $date = esc_html( date_i18n( 'F j, Y g:i a', strtotime( $req['date'] ) ) );
+
+                foreach ( $attendees as $att ) {
+                    $name = esc_html( trim( $att['first_name'] . ' ' . $att['last_name'] ) );
+                    $paid = $att['amount_paid'] ? sprintf( esc_html__( '$%s', 'tta' ), number_format_i18n( $att['amount_paid'], 2 ) ) : '&ndash;';
+                    echo '<tr data-attendee-id="' . esc_attr( $att['id'] ) . '">';
+                    echo '<td>' . $date . '</td>';
+                    echo '<td>' . $name . '</td>';
+                    echo '<td>' . $event_link . '</td>';
+                    echo '<td>' . $paid . '</td>';
+                    echo '<td><button type="button" class="tta-refund-cancel-attendee" data-attendee="' . esc_attr( $att['id'] ) . '">' . esc_html__( 'Cancel Attendance and Issue Refund', 'tta' ) . '</button></td>';
+                    echo '</tr>';
+                }
             }
+
+            echo '</tbody></table>';
         } else {
             echo '<p>' . esc_html__( 'No refund requests found.', 'tta' ) . '</p>';
         }

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-refund-requests-admin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-refund-requests-admin.php
@@ -52,7 +52,12 @@ class TTA_Refund_Requests_Admin {
                     echo '<td>' . $name . '</td>';
                     echo '<td>' . $event_link . '</td>';
                     echo '<td>' . $paid . '</td>';
-                    echo '<td><button type="button" class="tta-refund-cancel-attendee" data-attendee="' . esc_attr( $att['id'] ) . '">' . esc_html__( 'Cancel Attendance and Issue Refund', 'tta' ) . '</button></td>';
+                    echo '<td>';
+                    echo '<input type="number" class="tta-refund-amount" step="0.01" style="width:70px" placeholder="' . esc_attr__( 'Full', 'tta' ) . '"> ';
+                    echo '<button type="button" class="tta-refund-cancel-attendee" data-attendee="' . esc_attr( $att['id'] ) . '">' . esc_html__( 'Refund & Cancel Attendance', 'tta' ) . '</button> ';
+                    echo '<button type="button" class="tta-refund-keep-attendee" data-attendee="' . esc_attr( $att['id'] ) . '">' . esc_html__( 'Refund & Keep Attendance', 'tta' ) . '</button> ';
+                    echo '<button type="button" class="tta-cancel-attendee" data-attendee="' . esc_attr( $att['id'] ) . '">' . esc_html__( 'Cancel Attendance (No Refund)', 'tta' ) . '</button>';
+                    echo '</td>';
                     echo '</tr>';
                 }
             }

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-refund-requests-admin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-refund-requests-admin.php
@@ -70,8 +70,12 @@ class TTA_Refund_Requests_Admin {
                         echo '</tr>';
                     }
 
-                    echo '</tbody></table></div></div></details>';
+                    echo '</tbody></table></div>';
+                } else {
+                    echo '<p>' . esc_html__( 'No attendees found.', 'tta' ) . '</p>';
                 }
+
+                echo '</div></details>';
             }
         } else {
             echo '<p>' . esc_html__( 'No refund requests found.', 'tta' ) . '</p>';

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/ajax/handlers/class-ajax-attendance.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/ajax/handlers/class-ajax-attendance.php
@@ -116,6 +116,8 @@ class TTA_Ajax_Attendance {
 
         TTA_Cache::flush();
 
+        tta_delete_refund_request( $tx['transaction_id'], intval( $att['ticket_id'] ) );
+
         if ( $should_notify ) {
             tta_notify_waitlist_ticket_available( intval( $att['ticket_id'] ) );
         }
@@ -237,6 +239,8 @@ class TTA_Ajax_Attendance {
         }
 
         TTA_Cache::flush();
+
+        tta_delete_refund_request( $tx['transaction_id'], intval( $att['ticket_id'] ) );
 
         wp_send_json_success( [ 'message' => __( 'Refund processed.', 'tta' ) ] );
     }

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/ajax/handlers/class-ajax-refund.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/ajax/handlers/class-ajax-refund.php
@@ -24,6 +24,12 @@ class TTA_Ajax_Refund {
         if ( ! $member_id ) {
             wp_send_json_error( [ 'message' => 'not_found' ] );
         }
+
+        // Cancel the attendee immediately so the seat becomes available.
+        $att = tta_get_attendee_by_tx_ticket( $tx_id, $ticket_id );
+        if ( $att ) {
+            tta_cancel_attendance_internal( intval( $att['id'] ) );
+        }
         $wpdb->insert( $hist_table, [
             'member_id'   => $member_id,
             'wpuserid'    => get_current_user_id(),

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/ajax/handlers/class-ajax-refund.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/ajax/handlers/class-ajax-refund.php
@@ -10,8 +10,9 @@ class TTA_Ajax_Refund {
         if ( ! is_user_logged_in() ) {
             wp_send_json_error( [ 'message' => __( 'You must be logged in.', 'tta' ) ] );
         }
-        $tx_id   = tta_sanitize_text_field( $_POST['transaction_id'] ?? '' );
-        $event_id= intval( $_POST['event_id'] ?? 0 );
+        $tx_id    = tta_sanitize_text_field( $_POST['transaction_id'] ?? '' );
+        $event_id = intval( $_POST['event_id'] ?? 0 );
+        $ticket_id= intval( $_POST['ticket_id'] ?? 0 );
         $reason  = tta_sanitize_textarea_field( $_POST['reason'] ?? '' );
         if ( ! $tx_id || ! $event_id ) {
             wp_send_json_error( [ 'message' => 'missing_data' ] );
@@ -28,7 +29,11 @@ class TTA_Ajax_Refund {
             'wpuserid'    => get_current_user_id(),
             'event_id'    => $event_id,
             'action_type' => 'refund_request',
-            'action_data' => wp_json_encode( [ 'transaction_id' => $tx_id, 'reason' => $reason ] ),
+            'action_data' => wp_json_encode( [
+                'transaction_id' => $tx_id,
+                'ticket_id'     => $ticket_id,
+                'reason'        => $reason,
+            ] ),
         ], [ '%d','%d','%d','%s','%s' ] );
         TTA_Cache::delete( 'tta_refund_requests' );
         wp_send_json_success( [ 'message' => __( 'Refund request submitted.', 'tta' ) ] );

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/ajax/handlers/class-ajax-refund.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/ajax/handlers/class-ajax-refund.php
@@ -25,21 +25,37 @@ class TTA_Ajax_Refund {
             wp_send_json_error( [ 'message' => 'not_found' ] );
         }
 
-        // Cancel the attendee immediately so the seat becomes available.
-        $att = tta_get_attendee_by_tx_ticket( $tx_id, $ticket_id );
+        // Gather attendee details before cancelling.
+        $att         = tta_get_attendee_by_tx_ticket( $tx_id, $ticket_id );
+        $att_details = [];
+        $amount      = 0;
         if ( $att ) {
+            $att_details = [
+                'first_name'  => $att['first_name'],
+                'last_name'   => $att['last_name'],
+                'email'       => $att['email'],
+                'phone'       => $att['phone'],
+            ];
+            $tx_row  = tta_get_transaction_by_gateway_id( $tx_id );
+            if ( $tx_row ) {
+                $amount = tta_get_ticket_price_from_transaction( $tx_row, $ticket_id );
+            }
             tta_cancel_attendance_internal( intval( $att['id'] ) );
         }
+
+        $action_data = [
+            'transaction_id' => $tx_id,
+            'ticket_id'     => $ticket_id,
+            'reason'        => $reason,
+            'attendee'      => array_merge( $att_details, [ 'amount_paid' => $amount ] ),
+        ];
+
         $wpdb->insert( $hist_table, [
             'member_id'   => $member_id,
             'wpuserid'    => get_current_user_id(),
             'event_id'    => $event_id,
             'action_type' => 'refund_request',
-            'action_data' => wp_json_encode( [
-                'transaction_id' => $tx_id,
-                'ticket_id'     => $ticket_id,
-                'reason'        => $reason,
-            ] ),
+            'action_data' => wp_json_encode( $action_data ),
         ], [ '%d','%d','%d','%s','%s' ] );
         TTA_Cache::delete( 'tta_refund_requests' );
         wp_send_json_success( [ 'message' => __( 'Refund request submitted.', 'tta' ) ] );

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/classes/class-tta-refund-processor.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/classes/class-tta-refund-processor.php
@@ -1,0 +1,110 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+class TTA_Refund_Processor {
+    /** Schedule cron event. */
+    public static function schedule_event() {
+        if ( ! wp_next_scheduled( 'tta_refund_request_cron' ) ) {
+            wp_schedule_event( time(), 'tta_ten_minutes', 'tta_refund_request_cron' );
+        }
+    }
+
+    /** Clear cron event. */
+    public static function clear_event() {
+        wp_clear_scheduled_hook( 'tta_refund_request_cron' );
+    }
+
+    /** Initialize hooks. */
+    public static function init() {
+        add_action( 'tta_after_purchase_logged', [ __CLASS__, 'handle_purchase' ], 10, 2 );
+        add_action( 'tta_refund_request_cron', [ __CLASS__, 'expire_requests' ] );
+        self::schedule_event();
+    }
+
+    /**
+     * Process pending refund requests when tickets are purchased.
+     *
+     * @param array $items   Items purchased.
+     * @param int   $user_id Buyer user ID.
+     */
+    public static function handle_purchase( array $items, $user_id ) {
+        foreach ( $items as $it ) {
+            $tid = intval( $it['ticket_id'] );
+            $qty = intval( $it['quantity'] ?? 1 );
+            for ( $i = 0; $i < $qty; $i++ ) {
+                $req = tta_get_next_refund_request_for_ticket( $tid );
+                if ( ! $req ) {
+                    break;
+                }
+                self::process_refund_request( $req );
+            }
+        }
+    }
+
+    /**
+     * Process a single refund request.
+     *
+     * @param array $req Refund request data.
+     */
+    public static function process_refund_request( array $req ) {
+        $tx = tta_get_transaction_by_gateway_id( $req['transaction_id'] );
+        if ( ! $tx ) {
+            tta_delete_refund_request( $req['transaction_id'], $req['ticket_id'] );
+            return;
+        }
+
+        $amount = tta_get_ticket_price_from_transaction( $tx, $req['ticket_id'] );
+        if ( $amount <= 0 ) {
+            $amount = floatval( $tx['amount'] );
+        }
+
+        $api = new TTA_AuthorizeNet_API();
+        $res = $api->refund( $amount, $tx['transaction_id'], $tx['card_last4'] );
+        if ( ! $res['success'] ) {
+            return;
+        }
+
+        global $wpdb;
+        $txn_table  = $wpdb->prefix . 'tta_transactions';
+        $hist_table = $wpdb->prefix . 'tta_memberhistory';
+
+        $wpdb->update(
+            $txn_table,
+            [ 'refunded' => floatval( $tx['refunded'] ) + $amount ],
+            [ 'id' => intval( $tx['id'] ) ],
+            [ '%f' ],
+            [ '%d' ]
+        );
+
+        $wpdb->insert(
+            $hist_table,
+            [
+                'member_id'   => intval( $tx['member_id'] ),
+                'wpuserid'    => intval( $tx['wpuserid'] ),
+                'event_id'    => intval( $req['event_id'] ),
+                'action_type' => 'refund',
+                'action_data' => wp_json_encode([
+                    'amount'         => $amount,
+                    'transaction_id' => $tx['transaction_id'],
+                    'attendee_id'    => 0,
+                    'cancel'         => 1,
+                ]),
+            ],
+            [ '%d','%d','%d','%s','%s' ]
+        );
+
+        tta_delete_refund_request( $req['transaction_id'], $req['ticket_id'] );
+    }
+
+    /** Expire refund requests less than two hours before the event. */
+    public static function expire_requests() {
+        $requests = tta_get_refund_requests();
+        $now = current_time( 'timestamp' );
+        foreach ( $requests as $req ) {
+            $ts = tta_get_event_start_timestamp( $req['event_id'] );
+            if ( $ts && ( $ts - 7200 ) <= $now ) {
+                tta_delete_refund_request( $req['transaction_id'], $req['ticket_id'] );
+            }
+        }
+    }
+}

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/classes/class-tta-transaction-logger.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/classes/class-tta-transaction-logger.php
@@ -142,19 +142,21 @@ class TTA_Transaction_Logger {
                 }
             }
 
-            foreach ( $unique_members as $m ) {
-                $wpdb->insert(
-                    $history_table,
-                    [
-                        'member_id'   => intval( $m['id'] ),
+        foreach ( $unique_members as $m ) {
+            $wpdb->insert(
+                $history_table,
+                [
+                    'member_id'   => intval( $m['id'] ),
                         'wpuserid'    => intval( $m['wpuserid'] ),
                         'event_id'    => intval( $event_id ),
                         'action_type' => 'purchase',
                         'action_data' => wp_json_encode( $history_data ),
                     ],
-                    [ '%d', '%d', '%d', '%s', '%s' ]
-                );
-            }
+                [ '%d', '%d', '%d', '%s', '%s' ]
+            );
         }
+        }
+
+        do_action( 'tta_after_purchase_logged', $items, $user_id );
     }
 }

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/views/tab-upcoming.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/views/tab-upcoming.php
@@ -35,38 +35,41 @@
           <?php foreach ( $ev['items'] as $it ) : ?>
             <div class="tta-ticket-details">
               <strong><?php echo esc_html( $it['ticket_name'] ); ?> (<?php echo intval( $it['quantity'] ); ?>)</strong>
+              <?php if ( isset( $it['final_price'] ) ) : ?>
+                <span class="tta-ticket-price"><?php printf( esc_html__( '$%s', 'tta' ), number_format_i18n( floatval( $it['final_price'] ), 2 ) ); ?></span>
+              <?php endif; ?>
               <ul class="tta-attendees">
               <?php foreach ( (array) ( $it['attendees'] ?? [] ) as $att ) : ?>
                 <li><?php echo esc_html( trim( $att['first_name'] . ' ' . $att['last_name'] ) . ' (' . $att['email'] . ')' ); ?></li>
               <?php endforeach; ?>
               </ul>
+              <div class="tta-refund-wrapper">
+                <?php if ( $ev['amount'] > 0 ) : ?>
+                  <a href="#" class="tta-refund-link" data-tx="<?php echo esc_attr( $ev['transaction_id'] ); ?>" data-event="<?php echo esc_attr( $ev['event_id'] ); ?>" data-ticket="<?php echo esc_attr( $it['ticket_id'] ); ?>">
+                    <?php esc_html_e( 'Cancel Attendance & Request a Refund', 'tta' ); ?>
+                  </a>
+                <?php else : ?>
+                  <a href="#" class="tta-cancel-link" data-tx="<?php echo esc_attr( $ev['transaction_id'] ); ?>" data-event="<?php echo esc_attr( $ev['event_id'] ); ?>" data-ticket="<?php echo esc_attr( $it['ticket_id'] ); ?>">
+                    <?php esc_html_e( 'Cancel Attendance', 'tta' ); ?>
+                  </a>
+                <?php endif; ?>
+                <form class="tta-refund-form" data-tx="<?php echo esc_attr( $ev['transaction_id'] ); ?>" data-event="<?php echo esc_attr( $ev['event_id'] ); ?>" data-ticket="<?php echo esc_attr( $it['ticket_id'] ); ?>">
+                  <label for="refund-<?php echo esc_attr( $ev['transaction_id'] . '-' . $it['ticket_id'] ); ?>">
+                    <?php esc_html_e( 'Refund Request Details', 'tta' ); ?>
+                  </label>
+                  <span class="description"><?php esc_html_e( 'tell us why you\'re requesting a refund', 'tta' ); ?></span>
+                  <textarea id="refund-<?php echo esc_attr( $ev['transaction_id'] . '-' . $it['ticket_id'] ); ?>" placeholder="<?php esc_attr_e( 'tell us why you\'re requesting a refund', 'tta' ); ?>"></textarea>
+                  <button type="button" class="tta-refund-submit" data-tx="<?php echo esc_attr( $ev['transaction_id'] ); ?>" data-ticket="<?php echo esc_attr( $it['ticket_id'] ); ?>">
+                    <?php echo $ev['amount'] > 0 ? esc_html__( 'Cancel Attendance & Request a Refund', 'tta' ) : esc_html__( 'Cancel Attendance', 'tta' ); ?>
+                  </button>
+                  <span class="tta-progress-spinner">
+                    <img class="tta-admin-progress-spinner-svg" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/loading.svg' ); ?>" alt="<?php esc_attr_e( 'Loading…', 'tta' ); ?>" />
+                  </span>
+                  <span class="tta-admin-progress-response"><p class="tta-admin-progress-response-p"></p></span>
+                </form>
+              </div>
             </div>
           <?php endforeach; ?>
-          <div class="tta-refund-wrapper">
-            <?php if ( $ev['amount'] > 0 ) : ?>
-              <a href="#" class="tta-refund-link" data-tx="<?php echo esc_attr( $ev['transaction_id'] ); ?>" data-event="<?php echo esc_attr( $ev['event_id'] ); ?>">
-                <?php esc_html_e( 'Cancel Attendance & Request a Refund', 'tta' ); ?>
-              </a>
-            <?php else : ?>
-              <a href="#" class="tta-cancel-link" data-tx="<?php echo esc_attr( $ev['transaction_id'] ); ?>" data-event="<?php echo esc_attr( $ev['event_id'] ); ?>">
-                <?php esc_html_e( 'Cancel Attendance', 'tta' ); ?>
-              </a>
-            <?php endif; ?>
-            <form class="tta-refund-form" data-tx="<?php echo esc_attr( $ev['transaction_id'] ); ?>" data-event="<?php echo esc_attr( $ev['event_id'] ); ?>">
-              <label for="refund-<?php echo esc_attr( $ev['transaction_id'] ); ?>">
-                <?php esc_html_e( 'Refund Request Details', 'tta' ); ?>
-              </label>
-              <span class="description"><?php esc_html_e( 'tell us why you\'re requesting a refund', 'tta' ); ?></span>
-              <textarea id="refund-<?php echo esc_attr( $ev['transaction_id'] ); ?>" placeholder="<?php esc_attr_e( 'tell us why you\'re requesting a refund', 'tta' ); ?>"></textarea>
-              <button type="button" class="tta-refund-submit" data-tx="<?php echo esc_attr( $ev['transaction_id'] ); ?>">
-                <?php echo $ev['amount'] > 0 ? esc_html__( 'Cancel Attendance & Request a Refund', 'tta' ) : esc_html__( 'Cancel Attendance', 'tta' ); ?>
-              </button>
-              <span class="tta-progress-spinner">
-                <img class="tta-admin-progress-spinner-svg" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/loading.svg' ); ?>" alt="<?php esc_attr_e( 'Loading…', 'tta' ); ?>" />
-              </span>
-              <span class="tta-admin-progress-response"><p class="tta-admin-progress-response-p"></p></span>
-            </form>
-          </div>
       <?php endforeach; ?>
   <?php else : ?>
       <p><?php esc_html_e( 'No upcoming events found.', 'tta' ); ?></p>

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
@@ -1780,6 +1780,7 @@ function tta_get_refund_requests() {
             'event_name'  => sanitize_text_field( $r['event_name'] ),
             'event_url'   => $r['page_id'] ? get_permalink( $r['page_id'] ) : '',
             'transaction_id' => sanitize_text_field( $data['transaction_id'] ?? '' ),
+            'ticket_id'   => intval( $data['ticket_id'] ?? 0 ),
             'reason'      => sanitize_text_field( $data['reason'] ?? '' ),
         ];
     }
@@ -1795,14 +1796,15 @@ function tta_get_refund_requests() {
  * @param int    $event_id      Event ID.
  * @return array[]
  */
-function tta_get_refund_request_attendees( $gateway_tx_id, $event_id ) {
+function tta_get_refund_request_attendees( $gateway_tx_id, $event_id, $ticket_id = 0 ) {
     $gateway_tx_id = sanitize_text_field( $gateway_tx_id );
     $event_id      = intval( $event_id );
+    $ticket_id     = intval( $ticket_id );
     if ( '' === $gateway_tx_id || ! $event_id ) {
         return [];
     }
 
-    $cache_key = 'refund_attendees_' . md5( $gateway_tx_id . '_' . $event_id );
+    $cache_key = 'refund_attendees_' . md5( $gateway_tx_id . '_' . $event_id . '_' . $ticket_id );
     $cached    = TTA_Cache::get( $cache_key );
     if ( false !== $cached ) {
         return $cached;
@@ -1829,8 +1831,10 @@ function tta_get_refund_request_attendees( $gateway_tx_id, $event_id ) {
         return [];
     }
 
-    $sql = "(SELECT a.id, a.ticket_id, a.first_name, a.last_name, a.email, a.phone FROM {$att_table} a JOIN {$ticket_table} t ON a.ticket_id = t.id WHERE a.transaction_id = %d AND t.event_ute_id = %s) UNION ALL (SELECT a.id, a.ticket_id, a.first_name, a.last_name, a.email, a.phone FROM {$att_archive} a JOIN {$ticket_archive} t ON a.ticket_id = t.id WHERE a.transaction_id = %d AND t.event_ute_id = %s) ORDER BY last_name, first_name";
-    $rows = $wpdb->get_results( $wpdb->prepare( $sql, $tx['id'], $ute_id, $tx['id'], $ute_id ), ARRAY_A );
+    $ticket_sql = $ticket_id ? ' AND a.ticket_id = %d' : '';
+    $sql = "(SELECT a.id, a.ticket_id, a.first_name, a.last_name, a.email, a.phone FROM {$att_table} a JOIN {$ticket_table} t ON a.ticket_id = t.id WHERE a.transaction_id = %d AND t.event_ute_id = %s{$ticket_sql}) UNION ALL (SELECT a.id, a.ticket_id, a.first_name, a.last_name, a.email, a.phone FROM {$att_archive} a JOIN {$ticket_archive} t ON a.ticket_id = t.id WHERE a.transaction_id = %d AND t.event_ute_id = %s{$ticket_sql}) ORDER BY last_name, first_name";
+    $params = $ticket_id ? [ $tx['id'], $ute_id, $ticket_id, $tx['id'], $ute_id, $ticket_id ] : [ $tx['id'], $ute_id, $tx['id'], $ute_id ];
+    $rows = $wpdb->get_results( $wpdb->prepare( $sql, ...$params ), ARRAY_A );
 
     $details = json_decode( $tx['details'], true );
     $price_map = [];

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
@@ -1772,16 +1772,22 @@ function tta_get_refund_requests() {
     $out = [];
     foreach ( $rows as $r ) {
         $data = json_decode( $r['action_data'], true );
+        $att = $data['attendee'] ?? [];
         $out[] = [
-            'date'        => $r['action_date'],
-            'member_id'   => intval( $r['member_id'] ),
-            'member_name' => trim( $r['first_name'] . ' ' . $r['last_name'] ),
-            'event_id'    => intval( $r['event_id'] ),
-            'event_name'  => sanitize_text_field( $r['event_name'] ),
-            'event_url'   => $r['page_id'] ? get_permalink( $r['page_id'] ) : '',
-            'transaction_id' => sanitize_text_field( $data['transaction_id'] ?? '' ),
-            'ticket_id'   => intval( $data['ticket_id'] ?? 0 ),
-            'reason'      => sanitize_text_field( $data['reason'] ?? '' ),
+            'date'          => $r['action_date'],
+            'member_id'     => intval( $r['member_id'] ),
+            'member_name'   => trim( $r['first_name'] . ' ' . $r['last_name'] ),
+            'event_id'      => intval( $r['event_id'] ),
+            'event_name'    => sanitize_text_field( $r['event_name'] ),
+            'event_url'     => $r['page_id'] ? get_permalink( $r['page_id'] ) : '',
+            'transaction_id'=> sanitize_text_field( $data['transaction_id'] ?? '' ),
+            'ticket_id'     => intval( $data['ticket_id'] ?? 0 ),
+            'reason'        => sanitize_text_field( $data['reason'] ?? '' ),
+            'first_name'    => sanitize_text_field( $att['first_name'] ?? '' ),
+            'last_name'     => sanitize_text_field( $att['last_name'] ?? '' ),
+            'email'         => sanitize_email( $att['email'] ?? '' ),
+            'phone'         => sanitize_text_field( $att['phone'] ?? '' ),
+            'amount_paid'   => isset( $att['amount_paid'] ) ? floatval( $att['amount_paid'] ) : 0,
         ];
     }
 
@@ -1931,6 +1937,46 @@ function tta_get_next_refund_request_for_ticket( $ticket_id ) {
         'event_id'      => intval( $row['event_id'] ),
         'transaction_id'=> sanitize_text_field( $data['transaction_id'] ?? '' ),
         'ticket_id'     => intval( $data['ticket_id'] ?? 0 ),
+    ];
+}
+
+/**
+ * Fetch a specific refund request by transaction and ticket.
+ *
+ * @param string $gateway_tx_id Gateway ID.
+ * @param int    $ticket_id     Ticket ID.
+ * @return array|null Request row or null.
+ */
+function tta_get_refund_request( $gateway_tx_id, $ticket_id ) {
+    global $wpdb;
+    $hist_table = $wpdb->prefix . 'tta_memberhistory';
+    $gateway_tx_id = sanitize_text_field( $gateway_tx_id );
+    $ticket_id     = intval( $ticket_id );
+    if ( '' === $gateway_tx_id ) {
+        return null;
+    }
+
+    $like_tx = '%' . $wpdb->esc_like( '"transaction_id":"' . $gateway_tx_id . '"' ) . '%';
+    $sql = "SELECT * FROM {$hist_table} WHERE action_type='refund_request' AND action_data LIKE %s";
+    $params = [ $like_tx ];
+    if ( $ticket_id ) {
+        $sql .= " AND action_data LIKE %s";
+        $params[] = '%' . $wpdb->esc_like( '"ticket_id":' . $ticket_id ) . '%';
+    }
+    $sql .= ' LIMIT 1';
+
+    $row = $wpdb->get_row( $wpdb->prepare( $sql, ...$params ), ARRAY_A );
+    if ( ! $row ) {
+        return null;
+    }
+    $data = json_decode( $row['action_data'], true );
+    return [
+        'member_id'     => intval( $row['member_id'] ),
+        'wpuserid'      => intval( $row['wpuserid'] ),
+        'event_id'      => intval( $row['event_id'] ),
+        'transaction_id'=> sanitize_text_field( $data['transaction_id'] ?? '' ),
+        'ticket_id'     => intval( $data['ticket_id'] ?? 0 ),
+        'attendee'      => $data['attendee'] ?? [],
     ];
 }
 

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
@@ -1871,6 +1871,34 @@ function tta_get_refund_request_attendees( $gateway_tx_id, $event_id, $ticket_id
 }
 
 /**
+ * Delete a pending refund request once processed.
+ *
+ * @param string $gateway_tx_id Gateway transaction ID.
+ * @param int    $ticket_id     Ticket ID.
+ */
+function tta_delete_refund_request( $gateway_tx_id, $ticket_id = 0 ) {
+    global $wpdb;
+    $hist_table = $wpdb->prefix . 'tta_memberhistory';
+    $gateway_tx_id = sanitize_text_field( $gateway_tx_id );
+    $ticket_id     = intval( $ticket_id );
+
+    if ( '' === $gateway_tx_id ) {
+        return;
+    }
+
+    $sql    = "DELETE FROM {$hist_table} WHERE action_type = 'refund_request' AND action_data LIKE %s";
+    $params = [ '%' . $wpdb->esc_like( '"transaction_id":"' . $gateway_tx_id . '"' ) . '%' ];
+
+    if ( $ticket_id ) {
+        $sql   .= ' AND action_data LIKE %s';
+        $params[] = '%' . $wpdb->esc_like( '"ticket_id":' . $ticket_id ) . '%';
+    }
+
+    $wpdb->query( $wpdb->prepare( $sql, ...$params ) );
+    TTA_Cache::delete( 'tta_refund_requests' );
+}
+
+/**
  * Retrieve the next upcoming event.
  *
  * @return array|null {

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
@@ -1753,10 +1753,19 @@ function tta_get_refund_requests() {
     global $wpdb;
     $hist_table   = $wpdb->prefix . 'tta_memberhistory';
     $members_table= $wpdb->prefix . 'tta_members';
-    $events_table = $wpdb->prefix . 'tta_events';
+    $events_table  = $wpdb->prefix . 'tta_events';
+    $archive_table = $wpdb->prefix . 'tta_events_archive';
 
     $rows = $wpdb->get_results(
-        "SELECT mh.member_id, mh.action_date, mh.action_data, mh.event_id, m.first_name, m.last_name, e.name AS event_name, e.page_id FROM {$hist_table} mh JOIN {$members_table} m ON mh.member_id = m.id JOIN {$events_table} e ON mh.event_id = e.id WHERE mh.action_type = 'refund_request' ORDER BY mh.action_date DESC",
+        "SELECT mh.member_id, mh.action_date, mh.action_data, mh.event_id, m.first_name, m.last_name,
+                COALESCE(e.name, ea.name) AS event_name,
+                COALESCE(e.page_id, ea.page_id) AS page_id
+           FROM {$hist_table} mh
+           JOIN {$members_table} m ON mh.member_id = m.id
+      LEFT JOIN {$events_table} e ON mh.event_id = e.id
+      LEFT JOIN {$archive_table} ea ON mh.event_id = ea.id
+          WHERE mh.action_type = 'refund_request'
+       ORDER BY mh.action_date DESC",
         ARRAY_A
     );
 

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
@@ -1899,6 +1899,204 @@ function tta_delete_refund_request( $gateway_tx_id, $ticket_id = 0 ) {
 }
 
 /**
+ * Fetch the next pending refund request for a ticket.
+ *
+ * @param int $ticket_id Ticket ID.
+ * @return array|null Request row or null.
+ */
+function tta_get_next_refund_request_for_ticket( $ticket_id ) {
+    global $wpdb;
+    $hist_table = $wpdb->prefix . 'tta_memberhistory';
+    $ticket_id  = intval( $ticket_id );
+    if ( ! $ticket_id ) {
+        return null;
+    }
+
+    $like = '%' . $wpdb->esc_like( '"ticket_id":' . $ticket_id ) . '%';
+    $row  = $wpdb->get_row(
+        $wpdb->prepare(
+            "SELECT * FROM {$hist_table} WHERE action_type='refund_request' AND action_data LIKE %s ORDER BY action_date ASC LIMIT 1",
+            $like
+        ),
+        ARRAY_A
+    );
+    if ( ! $row ) {
+        return null;
+    }
+
+    $data = json_decode( $row['action_data'], true );
+    return [
+        'member_id'     => intval( $row['member_id'] ),
+        'wpuserid'      => intval( $row['wpuserid'] ),
+        'event_id'      => intval( $row['event_id'] ),
+        'transaction_id'=> sanitize_text_field( $data['transaction_id'] ?? '' ),
+        'ticket_id'     => intval( $data['ticket_id'] ?? 0 ),
+    ];
+}
+
+/**
+ * Retrieve a transaction row by gateway transaction ID.
+ *
+ * @param string $gateway_tx_id Gateway ID.
+ * @return array|null Transaction row.
+ */
+function tta_get_transaction_by_gateway_id( $gateway_tx_id ) {
+    global $wpdb;
+    $tx_table = $wpdb->prefix . 'tta_transactions';
+    $gateway_tx_id = sanitize_text_field( $gateway_tx_id );
+    if ( '' === $gateway_tx_id ) {
+        return null;
+    }
+
+    $row = $wpdb->get_row(
+        $wpdb->prepare( "SELECT * FROM {$tx_table} WHERE transaction_id = %s", $gateway_tx_id ),
+        ARRAY_A
+    );
+    return $row ?: null;
+}
+
+/**
+ * Get the price paid for a ticket within a transaction.
+ *
+ * @param array $tx        Transaction row.
+ * @param int   $ticket_id Ticket ID.
+ * @return float Amount paid.
+ */
+function tta_get_ticket_price_from_transaction( array $tx, $ticket_id ) {
+    $ticket_id = intval( $ticket_id );
+    $details   = json_decode( $tx['details'] ?? '', true );
+    if ( is_array( $details ) ) {
+        foreach ( $details as $it ) {
+            if ( intval( $it['ticket_id'] ?? 0 ) === $ticket_id ) {
+                return floatval( $it['final_price'] ?? ( $it['price'] ?? 0 ) );
+            }
+        }
+    }
+    return 0.0;
+}
+
+/**
+ * Get the start timestamp for an event ID.
+ *
+ * @param int $event_id Event ID.
+ * @return int Timestamp or 0.
+ */
+function tta_get_event_start_timestamp( $event_id ) {
+    global $wpdb;
+    $events_table  = $wpdb->prefix . 'tta_events';
+    $archive_table = $wpdb->prefix . 'tta_events_archive';
+    $event_id = intval( $event_id );
+    if ( ! $event_id ) {
+        return 0;
+    }
+
+    $row = $wpdb->get_row(
+        $wpdb->prepare( "SELECT date, time FROM {$events_table} WHERE id = %d", $event_id ),
+        ARRAY_A
+    );
+    if ( ! $row ) {
+        $row = $wpdb->get_row(
+            $wpdb->prepare( "SELECT date, time FROM {$archive_table} WHERE id = %d", $event_id ),
+            ARRAY_A
+        );
+    }
+    if ( ! $row ) {
+        return 0;
+    }
+
+    $time = $row['time'] ? explode( '|', $row['time'] )[0] : '00:00';
+    return strtotime( $row['date'] . ' ' . $time );
+}
+
+/**
+ * Lookup an attendee row by gateway transaction ID and ticket ID.
+ *
+ * @param string $gateway_tx_id Gateway transaction ID.
+ * @param int    $ticket_id     Ticket ID.
+ * @return array|null Attendee row.
+ */
+function tta_get_attendee_by_tx_ticket( $gateway_tx_id, $ticket_id ) {
+    global $wpdb;
+    $att_table = $wpdb->prefix . 'tta_attendees';
+    $tx_table  = $wpdb->prefix . 'tta_transactions';
+    $gateway_tx_id = sanitize_text_field( $gateway_tx_id );
+    $ticket_id = intval( $ticket_id );
+    if ( '' === $gateway_tx_id || ! $ticket_id ) {
+        return null;
+    }
+    $tx_row = $wpdb->get_row( $wpdb->prepare( "SELECT id FROM {$tx_table} WHERE transaction_id = %s", $gateway_tx_id ), ARRAY_A );
+    if ( ! $tx_row ) {
+        return null;
+    }
+    $att = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$att_table} WHERE transaction_id = %d AND ticket_id = %d LIMIT 1", intval( $tx_row['id'] ), $ticket_id ), ARRAY_A );
+    return $att ?: null;
+}
+
+/**
+ * Cancel an attendee without Ajax context.
+ *
+ * @param int $attendee_id Attendee ID.
+ */
+function tta_cancel_attendance_internal( $attendee_id ) {
+    global $wpdb;
+    $att_table   = $wpdb->prefix . 'tta_attendees';
+    $ticket_table = $wpdb->prefix . 'tta_tickets';
+    $tx_table     = $wpdb->prefix . 'tta_transactions';
+    $hist_table   = $wpdb->prefix . 'tta_memberhistory';
+
+    $att = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$att_table} WHERE id = %d", $attendee_id ), ARRAY_A );
+    if ( ! $att ) {
+        return;
+    }
+
+    $ticket = $wpdb->get_row( $wpdb->prepare( "SELECT event_ute_id FROM {$ticket_table} WHERE id = %d", intval( $att['ticket_id'] ) ), ARRAY_A );
+    $tx     = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$tx_table} WHERE id = %d", intval( $att['transaction_id'] ) ), ARRAY_A );
+
+    $event_id = 0;
+    if ( $ticket && ! empty( $ticket['event_ute_id'] ) ) {
+        $event_id = (int) $wpdb->get_var( $wpdb->prepare( "SELECT id FROM {$wpdb->prefix}tta_events WHERE ute_id = %s UNION SELECT id FROM {$wpdb->prefix}tta_events_archive WHERE ute_id = %s LIMIT 1", $ticket['event_ute_id'], $ticket['event_ute_id'] ) );
+    }
+
+    if ( $tx ) {
+        $wpdb->insert(
+            $hist_table,
+            [
+                'member_id'   => intval( $tx['member_id'] ),
+                'wpuserid'    => intval( $tx['wpuserid'] ),
+                'event_id'    => $event_id,
+                'action_type' => 'refund',
+                'action_data' => wp_json_encode([
+                    'amount'         => 0,
+                    'transaction_id' => $tx['transaction_id'],
+                    'attendee_id'    => $attendee_id,
+                    'cancel'         => 1,
+                ]),
+            ],
+            [ '%d','%d','%d','%s','%s' ]
+        );
+    }
+
+    $wpdb->delete( $att_table, [ 'id' => $attendee_id ], [ '%d' ] );
+    $should_notify = false;
+    if ( $ticket ) {
+        $current = (int) $wpdb->get_var( $wpdb->prepare( "SELECT ticketlimit FROM {$ticket_table} WHERE id = %d", intval( $att['ticket_id'] ) ) );
+        $after   = $current + 1;
+        $should_notify = ( $current <= 0 && $after > 0 );
+
+        $wpdb->query( $wpdb->prepare( "UPDATE {$ticket_table} SET ticketlimit = ticketlimit + 1 WHERE id = %d", intval( $att['ticket_id'] ) ) );
+        if ( ! empty( $ticket['event_ute_id'] ) ) {
+            TTA_Cache::delete( 'tickets_' . $ticket['event_ute_id'] );
+        }
+    }
+
+    TTA_Cache::flush();
+
+    if ( $should_notify ) {
+        tta_notify_waitlist_ticket_available( intval( $att['ticket_id'] ) );
+    }
+}
+
+/**
  * Retrieve the next upcoming event.
  *
  * @return array|null {

--- a/app/public/wp-content/plugins/tta-management-plugin/tests/HelpersTest.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/tests/HelpersTest.php
@@ -461,7 +461,18 @@ class HelpersTest extends TestCase {
             [
                 'member_id' => 7,
                 'action_date' => '2025-07-01 10:00:00',
-                'action_data' => json_encode(['transaction_id'=>'tx99','reason'=>'Changed plans']),
+                'action_data' => json_encode([
+                    'transaction_id' => 'tx99',
+                    'ticket_id' => 3,
+                    'reason' => 'Changed plans',
+                    'attendee' => [
+                        'first_name'  => 'Ann',
+                        'last_name'   => 'Bee',
+                        'email'       => 'a@example.com',
+                        'phone'       => '123',
+                        'amount_paid' => 10.00,
+                    ],
+                ]),
                 'event_id' => 5,
                 'first_name' => 'Ann',
                 'last_name' => 'Bee',
@@ -474,6 +485,9 @@ class HelpersTest extends TestCase {
         $rows = tta_get_refund_requests();
         $this->assertCount(1, $rows);
         $this->assertSame('Ann Bee', $rows[0]['member_name']);
+        $this->assertSame('Ann', $rows[0]['first_name']);
+        $this->assertSame('a@example.com', $rows[0]['email']);
+        $this->assertSame(10.0, $rows[0]['amount_paid']);
         $this->assertSame(1, $wpdb->results_calls);
         $cached = tta_get_refund_requests();
         $this->assertSame(1, $wpdb->results_calls);

--- a/app/public/wp-content/plugins/tta-management-plugin/trying-to-adult-management-plugin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/trying-to-adult-management-plugin.php
@@ -111,6 +111,7 @@ require_once TTA_PLUGIN_DIR . 'includes/frontend/class-become-member-page.php';
 require_once TTA_PLUGIN_DIR . 'includes/cart/class-cart.php';
 require_once TTA_PLUGIN_DIR . 'includes/cart/class-cart-cleanup.php';
 require_once TTA_PLUGIN_DIR . 'includes/classes/class-tta-event-archiver.php';
+require_once TTA_PLUGIN_DIR . 'includes/classes/class-tta-refund-processor.php';
 require_once TTA_PLUGIN_DIR . 'includes/database-testing/class-tta-sample-data.php';
 
 
@@ -119,9 +120,11 @@ require_once TTA_PLUGIN_DIR . 'includes/database-testing/class-tta-sample-data.p
 register_activation_hook( __FILE__, array( 'TTA_DB_Setup', 'install' ) );
 register_activation_hook( __FILE__, array( 'TTA_Cart_Cleanup', 'schedule_event' ) );
 register_activation_hook( __FILE__, array( 'TTA_Event_Archiver', 'schedule_event' ) );
+register_activation_hook( __FILE__, array( 'TTA_Refund_Processor', 'schedule_event' ) );
 register_deactivation_hook( __FILE__, array( 'TTA_DB_Setup', 'uninstall' ) );
 register_deactivation_hook( __FILE__, array( 'TTA_Cart_Cleanup', 'clear_event' ) );
 register_deactivation_hook( __FILE__, array( 'TTA_Event_Archiver', 'clear_event' ) );
+register_deactivation_hook( __FILE__, array( 'TTA_Refund_Processor', 'clear_event' ) );
 
 // Initialize plugin
 add_action( 'plugins_loaded', array( 'TTA_Plugin', 'init' ) );
@@ -158,6 +161,7 @@ class TTA_Plugin {
         // Expired cart cleanup
         TTA_Cart_Cleanup::init();
         TTA_Event_Archiver::init();
+        TTA_Refund_Processor::init();
 
         // Clear plugin caches after a successful checkout
         add_action( 'tta_checkout_complete', [ 'TTA_Cache', 'flush' ] );

--- a/docs/MemberDashboard.md
+++ b/docs/MemberDashboard.md
@@ -17,8 +17,8 @@ shows:
 - Event date and time
 - Event location
 - The total amount paid for the transaction
-- Each ticket purchased with the attendee names and emails
-- A link to request a refund (paid events) or cancel attendance (free events) which reveals a small form
+- Each ticket purchased with the attendee names and emails and its individual price
+- A separate link for each ticket to request a refund (paid events) or cancel attendance (free events) which reveals a small form
 - Submitting the form shows a spinner and records a `refund_request` entry in `tta_memberhistory`. Administrators can review requests on the **TTA Refund Requests** admin page.
 
 Events are loaded chronologically and the layout supports any number of events.

--- a/docs/MemberDashboard.md
+++ b/docs/MemberDashboard.md
@@ -19,7 +19,7 @@ shows:
 - The total amount paid for the transaction
 - Each ticket purchased with the attendee names and emails and its individual price
 - A separate link for each ticket to request a refund (paid events) or cancel attendance (free events) which reveals a small form
-- Submitting the form shows a spinner and records a `refund_request` entry in `tta_memberhistory`. The attendee is removed immediately. The refund is processed automatically once another member buys that ticket, otherwise the request expires two hours before the event. Administrators can review pending requests on the **TTA Refund Requests** admin page.
+- Submitting the form shows a spinner and records a `refund_request` entry in `tta_memberhistory`. The attendee is removed immediately. The refund is processed automatically once another member buys that ticket, otherwise the request expires two hours before the event. Administrators can review pending requests on the **TTA Refund Requests** admin page where they remain listed until processed.
 
 Events are loaded chronologically and the layout supports any number of events.
 Attendee details are pulled from the transaction history and stored in the

--- a/docs/MemberDashboard.md
+++ b/docs/MemberDashboard.md
@@ -19,7 +19,7 @@ shows:
 - The total amount paid for the transaction
 - Each ticket purchased with the attendee names and emails and its individual price
 - A separate link for each ticket to request a refund (paid events) or cancel attendance (free events) which reveals a small form
-- Submitting the form shows a spinner and records a `refund_request` entry in `tta_memberhistory`. Administrators can review requests on the **TTA Refund Requests** admin page.
+- Submitting the form shows a spinner and records a `refund_request` entry in `tta_memberhistory`. The attendee is removed immediately. The refund is processed automatically once another member buys that ticket, otherwise the request expires two hours before the event. Administrators can review pending requests on the **TTA Refund Requests** admin page.
 
 Events are loaded chronologically and the layout supports any number of events.
 Attendee details are pulled from the transaction history and stored in the

--- a/docs/RefundRequestsAdmin.md
+++ b/docs/RefundRequestsAdmin.md
@@ -2,4 +2,6 @@
 
 The **TTA Refund Requests** admin screen lists every refund submitted from a member's dashboard. Entries appear in a simple table showing when the request was made, the attendee name, the event and the amount paid for that ticket. Each row includes a **Cancel Attendance and Issue Refund** button which both refunds the payment and removes the attendee from the event.
 
+If a member purchased multiple tickets in the same transaction the request specifies the ticket ID so only the relevant attendee(s) appear in the table.
+
 After a refund and cancellation the ticket inventory is increased automatically so other members may purchase the newly available spot.

--- a/docs/RefundRequestsAdmin.md
+++ b/docs/RefundRequestsAdmin.md
@@ -11,3 +11,4 @@ table refreshes automatically whenever a new refund request is submitted from th
 member dashboard.
 Each refund request is displayed as a collapsible section. Click the summary line to reveal the attendee table and action buttons.
 If no attendees exist for the transaction a notice is displayed in place of the table.
+Archived events are also supported, ensuring past refund requests still show the associated event name and page link.

--- a/docs/RefundRequestsAdmin.md
+++ b/docs/RefundRequestsAdmin.md
@@ -1,10 +1,8 @@
 # TTA Refund Requests Page
 
-The **TTA Refund Requests** admin screen lists every refund submitted from a member's dashboard. Entries appear in a simple table showing when the request was made, the attendee name, the event and the amount paid for that ticket. Each row provides buttons to **Refund & Cancel Attendance**, **Refund & Keep Attendance** or **Cancel Attendance (No Refund)**. Entering a value in the **Refund $** field issues a partial refund; leaving it blank refunds the full amount.
+The **TTA Refund Requests** admin screen lists every refund submitted from a member's dashboard. Entries appear in a table showing when the request was made, the attendee name, the event and the amount paid for that ticket. Requests remain visible until the refund is processed automatically or the event has passed so administrators can review all outstanding items.
 
 If a member purchased multiple tickets in the same transaction the request specifies the ticket ID so only the relevant attendee(s) appear in the table.
 
 After a refund and cancellation the ticket inventory is increased automatically so other members may purchase the newly available spot.
-Processed requests are removed from the table immediately after any action button succeeds so admins only see outstanding requests.
-
-When a refund request is made the attendee is cancelled right away. The request remains pending until another member purchases that ticket. At that point the refund is issued automatically. Any requests still pending within two hours of the event are removed with no refund.
+Processed requests disappear from the list once the refund is issued or the request expires. When a refund request is submitted the attendee is cancelled immediately so the seat becomes available. The refund is automatically processed once another member purchases the ticket. Any requests still pending within two hours of the event are removed without a refund.

--- a/docs/RefundRequestsAdmin.md
+++ b/docs/RefundRequestsAdmin.md
@@ -1,14 +1,5 @@
 # TTA Refund Requests Page
 
-The **TTA Refund Requests** screen lists every refund request submitted by members.
-Each request shows the date, member name, event link and the reason given. Below
-that a full attendee table mirrors the one used on the **Tickets** screen. Admins
-can refund or cancel each attendee directly from this page.
+The **TTA Refund Requests** admin screen lists every refund submitted from a member's dashboard. Entries appear in a simple table showing when the request was made, the attendee name, the event and the amount paid for that ticket. Each row includes a **Cancel Attendance and Issue Refund** button which both refunds the payment and removes the attendee from the event.
 
-For context the member's history summary is displayed, indicating how many times
-they have previously requested refunds, cancelled attendance, or no‑showed. The
-table refreshes automatically whenever a new refund request is submitted from the
-member dashboard.
-Each refund request is displayed as a collapsible section. Click the summary line to reveal the attendee table and action buttons.
-If no attendees exist for the transaction a notice is displayed in place of the table.
-Archived events are also supported, ensuring past refund requests still show the associated event name and page link.
+After a refund and cancellation the ticket inventory is increased automatically so other members may purchase the newly available spot.

--- a/docs/RefundRequestsAdmin.md
+++ b/docs/RefundRequestsAdmin.md
@@ -6,3 +6,5 @@ If a member purchased multiple tickets in the same transaction the request speci
 
 After a refund and cancellation the ticket inventory is increased automatically so other members may purchase the newly available spot.
 Processed requests are removed from the table immediately after any action button succeeds so admins only see outstanding requests.
+
+When a refund request is made the attendee is cancelled right away. The request remains pending until another member purchases that ticket. At that point the refund is issued automatically. Any requests still pending within two hours of the event are removed with no refund.

--- a/docs/RefundRequestsAdmin.md
+++ b/docs/RefundRequestsAdmin.md
@@ -10,3 +10,4 @@ they have previously requested refunds, cancelled attendance, or no‑showed. Th
 table refreshes automatically whenever a new refund request is submitted from the
 member dashboard.
 Each refund request is displayed as a collapsible section. Click the summary line to reveal the attendee table and action buttons.
+If no attendees exist for the transaction a notice is displayed in place of the table.

--- a/docs/RefundRequestsAdmin.md
+++ b/docs/RefundRequestsAdmin.md
@@ -1,7 +1,8 @@
 # TTA Refund Requests Page
 
-The **TTA Refund Requests** admin screen lists every refund submitted from a member's dashboard. Entries appear in a simple table showing when the request was made, the attendee name, the event and the amount paid for that ticket. Each row includes a **Cancel Attendance and Issue Refund** button which both refunds the payment and removes the attendee from the event.
+The **TTA Refund Requests** admin screen lists every refund submitted from a member's dashboard. Entries appear in a simple table showing when the request was made, the attendee name, the event and the amount paid for that ticket. Each row provides buttons to **Refund & Cancel Attendance**, **Refund & Keep Attendance** or **Cancel Attendance (No Refund)**. Entering a value in the **Refund $** field issues a partial refund; leaving it blank refunds the full amount.
 
 If a member purchased multiple tickets in the same transaction the request specifies the ticket ID so only the relevant attendee(s) appear in the table.
 
 After a refund and cancellation the ticket inventory is increased automatically so other members may purchase the newly available spot.
+Processed requests are removed from the table immediately after any action button succeeds so admins only see outstanding requests.


### PR DESCRIPTION
## Summary
- fix closing tags for refund requests admin
- mention empty state for refund requests admin

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_686e74666e8c8320b9d3c957b17d9aa6