### PR TITLE
Add admin refund actions

### DIFF
--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-refund-requests-admin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-refund-requests-admin.php
@@ -24,26 +24,53 @@ class TTA_Refund_Requests_Admin {
 
     public function render_page() {
         echo '<div class="wrap"><h1>' . esc_html__( 'Refund Requests', 'tta' ) . '</h1>';
-        $requests = tta_get_refund_requests();
+
+        if ( isset( $_POST['tta_manual_refund'] ) && check_admin_referer( 'tta_manual_refund_action', 'tta_manual_refund_nonce' ) ) {
+            $tx_id    = sanitize_text_field( $_POST['tx'] ?? '' );
+            $ticket_id= intval( $_POST['ticket'] ?? 0 );
+            $req      = tta_get_refund_request( $tx_id, $ticket_id );
+            if ( $req ) {
+                TTA_Refund_Processor::process_refund_request( $req );
+                echo '<div class="updated"><p>' . esc_html__( 'Refund processed.', 'tta' ) . '</p></div>';
+            } else {
+                echo '<div class="error"><p>' . esc_html__( 'Refund request not found.', 'tta' ) . '</p></div>';
+            }
+            $requests = tta_get_refund_requests();
+        } else {
+            $requests = tta_get_refund_requests();
+        }
+
         if ( $requests ) {
             echo '<table class="widefat fixed striped"><thead><tr>';
             echo '<th>' . esc_html__( 'Requested', 'tta' ) . '</th>';
             echo '<th>' . esc_html__( 'Name', 'tta' ) . '</th>';
             echo '<th>' . esc_html__( 'Event', 'tta' ) . '</th>';
             echo '<th>' . esc_html__( 'Paid', 'tta' ) . '</th>';
+            echo '<th>' . esc_html__( 'Details', 'tta' ) . '</th>';
+            echo '<th>' . esc_html__( 'Actions', 'tta' ) . '</th>';
             echo '</tr></thead><tbody>';
 
             foreach ( $requests as $req ) {
                 $event_name = esc_html( $req['event_name'] );
                 $event_link = $req['event_url'] ? '<a href="' . esc_url( $req['event_url'] ) . '">' . $event_name . '</a>' : $event_name;
-                $date = esc_html( date_i18n( 'F j, Y g:i a', strtotime( $req['date'] ) ) );
-                $name = esc_html( trim( $req['first_name'] . ' ' . $req['last_name'] ) );
-                $paid = $req['amount_paid'] ? sprintf( esc_html__( '$%s', 'tta' ), number_format_i18n( $req['amount_paid'], 2 ) ) : '&ndash;';
+                $date  = esc_html( date_i18n( 'F j, Y g:i a', strtotime( $req['date'] ) ) );
+                $name  = esc_html( trim( $req['first_name'] . ' ' . $req['last_name'] ) );
+                $paid  = $req['amount_paid'] ? sprintf( esc_html__( '$%s', 'tta' ), number_format_i18n( $req['amount_paid'], 2 ) ) : '&ndash;';
+                $reason= esc_html( $req['reason'] );
                 echo '<tr>';
                 echo '<td>' . $date . '</td>';
                 echo '<td>' . $name . '</td>';
                 echo '<td>' . $event_link . '</td>';
                 echo '<td>' . $paid . '</td>';
+                echo '<td>' . $reason . '</td>';
+                echo '<td>';
+                echo '<form method="post" style="display:inline;">';
+                wp_nonce_field( 'tta_manual_refund_action', 'tta_manual_refund_nonce' );
+                echo '<input type="hidden" name="tx" value="' . esc_attr( $req['transaction_id'] ) . '">';
+                echo '<input type="hidden" name="ticket" value="' . esc_attr( $req['ticket_id'] ) . '">';
+                echo '<input type="submit" name="tta_manual_refund" class="button" value="' . esc_attr__( 'Refund Now', 'tta' ) . '">';
+                echo '</form>';
+                echo '</td>';
                 echo '</tr>';
             }
 

--- a/docs/RefundRequestsAdmin.md
+++ b/docs/RefundRequestsAdmin.md
@@ -1,8 +1,8 @@
 # TTA Refund Requests Page
 
-The **TTA Refund Requests** admin screen lists every refund submitted from a member's dashboard. Entries appear in a table showing when the request was made, the attendee name, the event and the amount paid for that ticket. Requests remain visible until the refund is processed automatically or the event has passed so administrators can review all outstanding items.
+The **TTA Refund Requests** admin screen lists every refund submitted from a member's dashboard. Entries appear in a table showing when the request was made, the attendee name, the event and the amount paid for that ticket. Each row also shows the details typed by the member when they requested the refund and includes a **Refund Now** button so administrators can process the refund immediately. Requests remain visible until the refund is processed automatically or the event has passed so administrators can review all outstanding items.
 
 If a member purchased multiple tickets in the same transaction the request specifies the ticket ID so only the relevant attendee(s) appear in the table.
 
-After a refund and cancellation the ticket inventory is increased automatically so other members may purchase the newly available spot.
+After a refund and cancellation the ticket inventory is increased automatically so other members may purchase the newly available spot. Clicking **Refund Now** processes the refund immediately using Authorize.Net and removes the pending request so the ticket will not be refunded a second time when another purchase occurs.
 Processed requests disappear from the list once the refund is issued or the request expires. When a refund request is submitted the attendee is cancelled immediately so the seat becomes available. The refund is automatically processed once another member purchases the ticket. Any requests still pending within two hours of the event are removed without a refund.


### PR DESCRIPTION
## Summary
- allow admins to manually refund a request from the Refund Requests page
- display refund request details text
- document the Refund Now button behaviour

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_686e9a72f5ac83208ec3ead0e239b06a