### PR TITLE
Add pending refund handling

### DIFF
--- a/app/public/wp-content/plugins/tta-management-plugin/assets/js/backend/admin.js
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/js/backend/admin.js
@@ -996,6 +996,37 @@ $(document).on('click', '.tta-remove-waitlist-entry', function(e){
 
   $(document).on('click', '.tta-cancel-attendee', handleCancel);
 
+  function handleRefundRequest(e, mode){
+    e.preventDefault();
+    var $row = $(e.currentTarget).closest('tr[data-request]');
+    var tx  = $(e.currentTarget).data('tx');
+    var ticket = $(e.currentTarget).data('ticket');
+    var action = (mode === 'delete') ? 'tta_delete_refund_request' : 'tta_process_refund_request';
+    var data = {
+      action: action,
+      tx: tx,
+      ticket: ticket,
+      nonce: TTA_Ajax.attendee_admin_nonce
+    };
+    $.post(TTA_Ajax.ajax_url, data, function(res){
+      if(res.success){
+        $row.remove();
+        alert(res.data && res.data.message ? res.data.message : 'OK');
+      }else{
+        alert(res.data && res.data.message ? res.data.message : 'Error');
+      }
+    }, 'json');
+  }
+
+  $(document).on('click', '.tta-refund-request-process', function(e){
+    var mode = $(this).data('mode');
+    handleRefundRequest(e, mode);
+  });
+
+  $(document).on('click', '.tta-refund-request-delete', function(e){
+    handleRefundRequest(e, 'delete');
+  });
+
   // Inline edit toggle for Email & SMS templates
   $(document).on('click', '.widefat tbody tr[data-comms-key]', function(e){
     if ( $(e.target).is('a, button, input, textarea, select') ) return;

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/views/tickets-edit.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/views/tickets-edit.php
@@ -7,6 +7,13 @@ $waitlist_table = $wpdb->prefix . 'tta_waitlist';
 
 // 1) Fetch all tickets for this event:
 $event_ute_id = esc_sql( $ticket['event_ute_id'] );
+$event_id     = (int) $wpdb->get_var(
+    $wpdb->prepare(
+        "SELECT id FROM {$wpdb->prefix}tta_events WHERE ute_id = %s UNION SELECT id FROM {$wpdb->prefix}tta_events_archive WHERE ute_id = %s LIMIT 1",
+        $event_ute_id,
+        $event_ute_id
+    )
+);
 $tickets = $wpdb->get_results(
     "SELECT * FROM {$tickets_table} WHERE event_ute_id = '{$event_ute_id}' ORDER BY id ASC",
     ARRAY_A
@@ -32,8 +39,10 @@ $tickets = $wpdb->get_results(
     );
 
     // Fetch confirmed attendees for this ticket
-    $attendees     = tta_get_ticket_attendees( $tid );
-    $att_count     = count( $attendees );
+    $attendees      = tta_get_ticket_attendees( $tid );
+    $att_count      = count( $attendees );
+    $pending_refs   = tta_get_ticket_pending_refund_attendees( $tid, $event_id );
+    $pending_count  = count( $pending_refs );
 
     $waitlist_count = count( $waitlist_entries );
 
@@ -234,7 +243,7 @@ $tickets = $wpdb->get_results(
 
       <details class="tta-ticket-attendees">
         <summary>
-          <?php esc_html_e( 'Attendees', 'tta' ); ?>
+          <?php esc_html_e( 'Verified Attendees', 'tta' ); ?>
           <span class="tta-tooltip-icon" data-tooltip="<?php esc_attr_e( 'People who purchased this ticket.', 'tta' ); ?>">
             <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help">
           </span>
@@ -330,6 +339,104 @@ $tickets = $wpdb->get_results(
           </div>
         <?php else : ?>
           <p class="no-waitlist"><?php esc_html_e( 'No attendees.', 'tta' ); ?></p>
+        <?php endif; ?>
+      </details>
+
+      <details class="tta-ticket-attendees">
+        <summary>
+          <?php esc_html_e( 'Attendees With Pending Refund Requests', 'tta' ); ?>
+          <span class="tta-tooltip-icon" data-tooltip="<?php esc_attr_e( 'Members who cancelled and await refund.', 'tta' ); ?>">
+            <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help">
+          </span>
+          (<?php echo $pending_count; ?>)
+        </summary>
+        <?php if ( $pending_refs ) : ?>
+          <div class="tta-wl-info-wrapper">
+            <table class="tta-wl-info-table">
+              <thead>
+                <tr>
+                  <th>
+                    <span class="tta-tooltip-icon" data-tooltip="<?php esc_attr_e( 'Attendee first and last name.', 'tta' ); ?>">
+                      <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="?">
+                    </span>
+                    <?php esc_html_e( 'Name', 'tta' ); ?>
+                  </th>
+                  <th>
+                    <span class="tta-tooltip-icon" data-tooltip="<?php esc_attr_e( 'Attendee email address.', 'tta' ); ?>">
+                      <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="?">
+                    </span>
+                    <?php esc_html_e( 'Email', 'tta' ); ?>
+                  </th>
+                  <th>
+                    <span class="tta-tooltip-icon" data-tooltip="<?php esc_attr_e( 'Phone number provided at checkout.', 'tta' ); ?>">
+                      <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="?">
+                    </span>
+                    <?php esc_html_e( 'Phone', 'tta' ); ?>
+                  </th>
+                  <th>
+                    <span class="tta-tooltip-icon" data-tooltip="<?php esc_attr_e( 'Amount charged for this ticket.', 'tta' ); ?>">
+                      <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="?">
+                    </span>
+                    <?php esc_html_e( 'Paid', 'tta' ); ?>
+                  </th>
+                  <th>
+                    <span class="tta-tooltip-icon" data-tooltip="<?php esc_attr_e( 'Specify a partial refund amount.', 'tta' ); ?>">
+                      <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="?">
+                    </span>
+                    <?php esc_html_e( 'Refund $', 'tta' ); ?>
+                  </th>
+                  <th>
+                    <span class="tta-tooltip-icon" data-tooltip="<?php esc_attr_e( 'Available actions for the attendee.', 'tta' ); ?>">
+                      <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="?">
+                    </span>
+                    <?php esc_html_e( 'Actions', 'tta' ); ?>
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <?php $last_gate = ''; foreach ( $pending_refs as $a ) : ?>
+                  <?php
+                  if ( $a['gateway_id'] !== $last_gate ) :
+                    $last_gate = $a['gateway_id'];
+                    $txid   = $a['gateway_id'] ? ' - ' . __( 'Transaction ID', 'tta' ) . ' ' . $a['gateway_id'] : '';
+                    $txdate = $a['created_at'] ? ' - ' . mysql2date( 'n/j/Y g:i a', $a['created_at'] ) : '';
+                  ?>
+                    <tr class="tta-transaction-group">
+                      <td colspan="6" style="background:#f9f9f9;font-weight:bold;">
+                        <?php echo esc_html( sprintf( __( 'Pending Refund%s%s', 'tta' ), $txid, $txdate ) ); ?>
+                      </td>
+                    </tr>
+                  <?php endif; ?>
+                  <?php
+                  $name  = trim( $a['first_name'] . ' ' . $a['last_name'] );
+                  $email = $a['email'];
+                  $phone = $a['phone'];
+                  $paid  = floatval( $a['amount_paid'] );
+                  ?>
+                  <tr data-request data-tx="<?php echo esc_attr( $a['gateway_id'] ); ?>" data-ticket="<?php echo esc_attr( $tid ); ?>" data-event="<?php echo esc_attr( $event_id ); ?>">
+                    <td><?php echo esc_html( $name ); ?></td>
+                    <td><?php echo esc_html( $email ); ?></td>
+                    <td><?php echo esc_html( $phone ); ?></td>
+                    <td><?php echo $paid ? sprintf( esc_html__( '$%s', 'tta' ), number_format_i18n( $paid, 2 ) ) : '&ndash;'; ?></td>
+                    <td>&ndash;</td>
+                    <td>
+                      <button type="button" class="tta-refund-request-process" data-mode="cancel" data-tx="<?php echo esc_attr( $a['gateway_id'] ); ?>" data-ticket="<?php echo esc_attr( $tid ); ?>">
+                        <?php esc_html_e( 'Refund & Cancel Attendance', 'tta' ); ?>
+                      </button>
+                      <button type="button" class="tta-refund-request-process" data-mode="keep" data-tx="<?php echo esc_attr( $a['gateway_id'] ); ?>" data-ticket="<?php echo esc_attr( $tid ); ?>">
+                        <?php esc_html_e( 'Refund & Keep Attendance', 'tta' ); ?>
+                      </button>
+                      <button type="button" class="tta-refund-request-delete" data-tx="<?php echo esc_attr( $a['gateway_id'] ); ?>" data-ticket="<?php echo esc_attr( $tid ); ?>">
+                        <?php esc_html_e( 'Cancel Attendance (No Refund)', 'tta' ); ?>
+                      </button>
+                    </td>
+                  </tr>
+                <?php endforeach; ?>
+              </tbody>
+            </table>
+          </div>
+        <?php else : ?>
+          <p class="no-waitlist"><?php esc_html_e( 'No pending refund requests.', 'tta' ); ?></p>
         <?php endif; ?>
       </details>
 

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/ajax/handlers/class-ajax-refund.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/ajax/handlers/class-ajax-refund.php
@@ -3,6 +3,8 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
 class TTA_Ajax_Refund {
     public static function init() {
         add_action( 'wp_ajax_tta_request_refund', [ __CLASS__, 'request_refund' ] );
+        add_action( 'wp_ajax_tta_process_refund_request', [ __CLASS__, 'process_request' ] );
+        add_action( 'wp_ajax_tta_delete_refund_request', [ __CLASS__, 'delete_request' ] );
     }
 
     public static function request_refund() {
@@ -59,6 +61,49 @@ class TTA_Ajax_Refund {
         ], [ '%d','%d','%d','%s','%s' ] );
         TTA_Cache::delete( 'tta_refund_requests' );
         wp_send_json_success( [ 'message' => __( 'Refund request submitted.', 'tta' ) ] );
+    }
+
+    /**
+     * Process a pending refund request via AJAX.
+     */
+    public static function process_request() {
+        check_ajax_referer( 'tta_attendee_admin_action', 'nonce' );
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( [ 'message' => 'forbidden' ] );
+        }
+
+        $tx_id     = tta_sanitize_text_field( $_POST['tx'] ?? '' );
+        $ticket_id = intval( $_POST['ticket'] ?? 0 );
+        if ( ! $tx_id || ! $ticket_id ) {
+            wp_send_json_error( [ 'message' => 'missing_data' ] );
+        }
+
+        $req = tta_get_refund_request( $tx_id, $ticket_id );
+        if ( ! $req ) {
+            wp_send_json_error( [ 'message' => 'not_found' ] );
+        }
+
+        TTA_Refund_Processor::process_refund_request( $req );
+        wp_send_json_success( [ 'message' => __( 'Refund processed.', 'tta' ) ] );
+    }
+
+    /**
+     * Delete a pending refund request without issuing a refund.
+     */
+    public static function delete_request() {
+        check_ajax_referer( 'tta_attendee_admin_action', 'nonce' );
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( [ 'message' => 'forbidden' ] );
+        }
+
+        $tx_id     = tta_sanitize_text_field( $_POST['tx'] ?? '' );
+        $ticket_id = intval( $_POST['ticket'] ?? 0 );
+        if ( ! $tx_id || ! $ticket_id ) {
+            wp_send_json_error( [ 'message' => 'missing_data' ] );
+        }
+
+        tta_delete_refund_request( $tx_id, $ticket_id );
+        wp_send_json_success( [ 'message' => __( 'Request cancelled.', 'tta' ) ] );
     }
 }
 TTA_Ajax_Refund::init();

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/classes/class-tta-refund-processor.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/classes/class-tta-refund-processor.php
@@ -58,8 +58,23 @@ class TTA_Refund_Processor {
             $amount = floatval( $tx['amount'] );
         }
 
-        $api = new TTA_AuthorizeNet_API();
-        $res = $api->refund( $amount, $tx['transaction_id'], $tx['card_last4'] );
+        $api         = new TTA_AuthorizeNet_API();
+        $status_res  = $api->get_transaction_status( $tx['transaction_id'] );
+        $status_str  = strtolower( $status_res['status'] ?? '' );
+        $should_void = ( false !== strpos( $status_str, 'pending' ) );
+
+        if ( $should_void ) {
+            $res = $api->void( $tx['transaction_id'] );
+        } else {
+            $res = $api->refund( $amount, $tx['transaction_id'], $tx['card_last4'] );
+            if ( ! $res['success'] ) {
+                $msg = strtolower( $res['error'] );
+                if ( false !== strpos( $msg, 'not meet the criteria' ) || false !== strpos( $msg, 'not settled' ) || false !== strpos( $msg, 'unsuccessful' ) ) {
+                    $res = $api->void( $tx['transaction_id'] );
+                }
+            }
+        }
+
         if ( ! $res['success'] ) {
             return;
         }
@@ -94,6 +109,7 @@ class TTA_Refund_Processor {
         );
 
         tta_delete_refund_request( $req['transaction_id'], $req['ticket_id'] );
+        TTA_Cache::flush();
     }
 
     /** Expire refund requests less than two hours before the event. */

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/views/tab-upcoming.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/views/tab-upcoming.php
@@ -38,11 +38,27 @@
               <?php if ( isset( $it['final_price'] ) ) : ?>
                 <span class="tta-ticket-price"><?php printf( esc_html__( '$%s', 'tta' ), number_format_i18n( floatval( $it['final_price'] ), 2 ) ); ?></span>
               <?php endif; ?>
+              <?php if ( ! empty( $it['refund_pending'] ) ) : ?>
+                <p class="tta-refund-pending">
+                  <?php
+                  $ra = $it['refund_attendee'] ?? [];
+                  $name = trim( ( $ra['first_name'] ?? '' ) . ' ' . ( $ra['last_name'] ?? '' ) );
+                  $email = $ra['email'] ?? '';
+                  if ( $name || $email ) {
+                      printf( esc_html__( '%1$s (%2$s) - refund request pending', 'tta' ), esc_html( $name ), esc_html( $email ) );
+                  } else {
+                      esc_html_e( 'Refund request pending', 'tta' );
+                  }
+                  ?>
+                </p>
+              <?php else : ?>
               <ul class="tta-attendees">
               <?php foreach ( (array) ( $it['attendees'] ?? [] ) as $att ) : ?>
                 <li><?php echo esc_html( trim( $att['first_name'] . ' ' . $att['last_name'] ) . ' (' . $att['email'] . ')' ); ?></li>
               <?php endforeach; ?>
               </ul>
+              <?php endif; ?>
+              <?php if ( empty( $it['refund_pending'] ) ) : ?>
               <div class="tta-refund-wrapper">
                 <?php if ( $ev['amount'] > 0 ) : ?>
                   <a href="#" class="tta-refund-link" data-tx="<?php echo esc_attr( $ev['transaction_id'] ); ?>" data-event="<?php echo esc_attr( $ev['event_id'] ); ?>" data-ticket="<?php echo esc_attr( $it['ticket_id'] ); ?>">
@@ -68,6 +84,7 @@
                   <span class="tta-admin-progress-response"><p class="tta-admin-progress-response-p"></p></span>
                 </form>
               </div>
+              <?php endif; ?>
             </div>
           <?php endforeach; ?>
       <?php endforeach; ?>

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
@@ -1178,8 +1178,9 @@ function tta_get_member_upcoming_events( $wp_user_id ) {
         ARRAY_A
     );
 
-    $events = [];
+    $events  = [];
     $txn_map = [];
+    $refunds = [];
     foreach ( $rows as $row ) {
         $data = json_decode( $row['action_data'], true );
         if ( ! is_array( $data ) ) {
@@ -1200,6 +1201,24 @@ function tta_get_member_upcoming_events( $wp_user_id ) {
             'amount'         => floatval( $data['amount'] ?? 0 ),
             'items'          => $data['items'] ?? [],
         ];
+    }
+
+    // Load refund requests for this member and merge counts
+    $member_id = (int) $wpdb->get_var( $wpdb->prepare( "SELECT id FROM {$wpdb->prefix}tta_members WHERE wpuserid = %d", $wp_user_id ) );
+    if ( $member_id ) {
+        foreach ( tta_get_refund_requests() as $req ) {
+            if ( intval( $req['member_id'] ) !== $member_id ) {
+                continue;
+            }
+            $tx  = $req['transaction_id'];
+            $tid = intval( $req['ticket_id'] );
+            $refunds[ $tx ][ $tid ] = $req;
+            if ( isset( $txn_map[ $tx ] ) ) {
+                $txn_map[ $tx ] += 1;
+            } else {
+                $txn_map[ $tx ] = 1;
+            }
+        }
     }
 
     if ( $txn_map && ! property_exists( $wpdb, 'results_data' ) ) {
@@ -1266,7 +1285,20 @@ function tta_get_member_upcoming_events( $wp_user_id ) {
                     );
                     $item['attendees'] = array_values( $attendees );
                     $item['quantity']  = count( $item['attendees'] );
-                    if ( $item['quantity'] > 0 ) {
+                    $item['refund_pending'] = false;
+                    if ( isset( $refunds[ $gateway_tx ][ $tid ] ) ) {
+                        $req  = $refunds[ $gateway_tx ][ $tid ];
+                        $item['refund_pending'] = true;
+                        $item['refund_attendee'] = [
+                            'first_name' => $req['first_name'],
+                            'last_name'  => $req['last_name'],
+                            'email'      => $req['email'],
+                        ];
+                        if ( 0 === $item['quantity'] ) {
+                            $item['quantity'] = 1;
+                        }
+                        $new_items[] = $item;
+                    } elseif ( $item['quantity'] > 0 ) {
                         $new_items[] = $item;
                     }
                 }
@@ -2052,6 +2084,50 @@ function tta_get_event_start_timestamp( $event_id ) {
 
     $time = $row['time'] ? explode( '|', $row['time'] )[0] : '00:00';
     return strtotime( $row['date'] . ' ' . $time );
+}
+
+/**
+ * Retrieve attendees with pending refund requests for a ticket.
+ *
+ * @param int $ticket_id Ticket ID.
+ * @param int $event_id  Event ID.
+ * @return array[]
+ */
+function tta_get_ticket_pending_refund_attendees( $ticket_id, $event_id ) {
+    $ticket_id = intval( $ticket_id );
+    $event_id  = intval( $event_id );
+    if ( ! $ticket_id || ! $event_id ) {
+        return [];
+    }
+
+    $cache_key = 'pending_refund_attendees_' . $ticket_id . '_' . $event_id;
+    $cached    = TTA_Cache::get( $cache_key );
+    if ( false !== $cached ) {
+        return $cached;
+    }
+
+    $requests  = tta_get_refund_requests();
+    $attendees = [];
+    foreach ( $requests as $req ) {
+        if ( intval( $req['ticket_id'] ) !== $ticket_id || intval( $req['event_id'] ) !== $event_id ) {
+            continue;
+        }
+        $tx = tta_get_transaction_by_gateway_id( $req['transaction_id'] );
+        $attendees[] = [
+            'first_name'    => sanitize_text_field( $req['first_name'] ),
+            'last_name'     => sanitize_text_field( $req['last_name'] ),
+            'email'         => sanitize_email( $req['email'] ),
+            'phone'         => sanitize_text_field( $req['phone'] ),
+            'amount_paid'   => floatval( $req['amount_paid'] ),
+            'gateway_id'    => sanitize_text_field( $req['transaction_id'] ),
+            'created_at'    => $tx['created_at'] ?? '',
+        ];
+    }
+
+    $ttl = empty( $attendees ) ? 60 : 300;
+    TTA_Cache::set( $cache_key, $attendees, $ttl );
+
+    return $attendees;
 }
 
 /**

--- a/docs/MemberDashboard.md
+++ b/docs/MemberDashboard.md
@@ -27,7 +27,7 @@ Attendee details are pulled from the transaction history and stored in the
 When a single checkout includes tickets for multiple events each event now
 receives its own history record so it appears individually in this list.
 Event thumbnails use the medium image size and are scaled to a consistent width so nothing is cropped.
-Attendee lists now reflect the database in real time. Individual refunds or cancellations remove the person from the list, and an event disappears entirely once all of its attendees are gone.
+Attendee lists now reflect the database in real time. When a member requests a refund the attendee is removed from the list but the ticket entry remains with a "refund request pending" note until another member buys the ticket or an admin processes the refund manually from the ticket editor. Events only disappear once no attendees or pending requests remain.
 
 ## Past Events Tab
 

--- a/docs/TicketAttendees.md
+++ b/docs/TicketAttendees.md
@@ -1,12 +1,6 @@
 ## Ticket Attendees
 
-The ticket editor displays an **Attendees** section for each ticket. This list
-shows every attendee who purchased that ticket in a single table. The table
-heading contains **Name**, **Email**, **Phone**, **Paid**, **Refund $** and
-**Actions** columns. Each heading includes a tooltip icon explaining the field.
-Each attendee occupies one row beneath the heading. Transactions are grouped by
-their numeric ID with the gateway transaction ID and purchase date displayed in
-the group heading.
+The ticket editor now shows two attendee tables for each ticket. **Verified Attendees** lists everyone who has successfully purchased the ticket. **Attendees With Pending Refund Requests** appears below it and shows members who cancelled and are waiting for another purchase before their refund is issued. Admins can process these requests immediately using the action buttons in this section. Both tables display the same columns: **Name**, **Email**, **Phone**, **Paid**, **Refund $** and **Actions**. Transactions are grouped by their numeric ID with the gateway transaction ID and purchase date displayed in the group heading.
 
 The **Paid** column shows the amount charged for that attendee's ticket. The
 **Refund $** field lets admins specify a partial refund before clicking either


### PR DESCRIPTION
## Summary
- hide refund form when a ticket refund is pending
- allow admins to process pending refund requests directly from ticket editor
- new AJAX endpoints for processing or deleting refund requests
- document manual refund handling
- void unsettled transactions automatically during refund processing

## Testing
- `composer install`
- `vendor/bin/phpunit --configuration phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_686eb068626c83208492e70b048930f8