### PR TITLE
Fix duplicate ticket entries on dashboard

### DIFF
--- a/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
@@ -1312,6 +1312,37 @@ function tta_get_member_upcoming_events( $wp_user_id ) {
         }
     }
 
+    // Split items so each attendee gets an individual entry
+    foreach ( $events as &$ev ) {
+        $split_items = [];
+        foreach ( $ev['items'] as $item ) {
+            if ( ! empty( $item['refund_pending'] ) ) {
+                $split_items[] = $item;
+                continue;
+            }
+            $attendees = $item['attendees'] ?? [];
+            $qty       = intval( $item['quantity'] ?? count( $attendees ) );
+            if ( $attendees ) {
+                foreach ( $attendees as $att ) {
+                    $clone = $item;
+                    $clone['attendees'] = [ $att ];
+                    $clone['quantity']  = 1;
+                    $split_items[] = $clone;
+                }
+            } elseif ( $qty > 1 ) {
+                for ( $i = 0; $i < $qty; $i++ ) {
+                    $clone = $item;
+                    $clone['quantity'] = 1;
+                    $split_items[] = $clone;
+                }
+            } else {
+                $split_items[] = $item;
+            }
+        }
+        $ev['items'] = $split_items;
+    }
+    unset( $ev );
+
     $ttl = empty( $events ) ? 60 : 300;
     TTA_Cache::set( $cache_key, $events, $ttl );
 

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
@@ -1316,24 +1316,39 @@ function tta_get_member_upcoming_events( $wp_user_id ) {
     foreach ( $events as &$ev ) {
         $split_items = [];
         foreach ( $ev['items'] as $item ) {
+            $attendees = $item['attendees'] ?? [];
             if ( ! empty( $item['refund_pending'] ) ) {
-                $split_items[] = $item;
+                // keep a row for the pending refund attendee
+                $pending            = $item;
+                $pending['quantity'] = 1;
+                $pending['attendees'] = [];
+                $split_items[]      = $pending;
+
+                // show remaining attendees separately with refund links
+                foreach ( $attendees as $att ) {
+                    $clone                     = $item;
+                    $clone['refund_pending']   = false;
+                    unset( $clone['refund_attendee'] );
+                    $clone['attendees']        = [ $att ];
+                    $clone['quantity']         = 1;
+                    $split_items[]             = $clone;
+                }
                 continue;
             }
-            $attendees = $item['attendees'] ?? [];
-            $qty       = intval( $item['quantity'] ?? count( $attendees ) );
+
+            $qty = intval( $item['quantity'] ?? count( $attendees ) );
             if ( $attendees ) {
                 foreach ( $attendees as $att ) {
-                    $clone = $item;
+                    $clone              = $item;
                     $clone['attendees'] = [ $att ];
                     $clone['quantity']  = 1;
-                    $split_items[] = $clone;
+                    $split_items[]      = $clone;
                 }
             } elseif ( $qty > 1 ) {
                 for ( $i = 0; $i < $qty; $i++ ) {
-                    $clone = $item;
-                    $clone['quantity'] = 1;
-                    $split_items[] = $clone;
+                    $clone              = $item;
+                    $clone['quantity']  = 1;
+                    $split_items[]      = $clone;
                 }
             } else {
                 $split_items[] = $item;

--- a/app/public/wp-content/plugins/tta-management-plugin/tests/HelpersTest.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/tests/HelpersTest.php
@@ -86,6 +86,8 @@ class HelpersTest extends TestCase {
         if (!function_exists('current_time')) { function current_time($type = 'mysql'){ return date('Y-m-d H:i:s'); } }
         if (!function_exists('get_option')) { function get_option($k,$d=null){ return $GLOBALS['options'][$k] ?? $d; } }
         if (!function_exists('update_option')) { function update_option($k,$v,$autoload=true){ $GLOBALS['options'][$k]=$v; } }
+        if (!function_exists('add_action')) { function add_action($t,$c,$p=10,$a=1){} }
+        if (!function_exists('add_filter')) { function add_filter($t,$c,$p=10,$a=1){} }
 
         $GLOBALS['transients'] = [];
         $GLOBALS['options'] = [];
@@ -250,6 +252,53 @@ class HelpersTest extends TestCase {
         $this->assertCount(2, $events[0]['items']);
         $this->assertSame('Ann', $events[0]['items'][0]['attendees'][0]['first_name']);
         $this->assertSame('Bob', $events[0]['items'][1]['attendees'][0]['first_name']);
+    }
+
+    public function test_get_member_upcoming_events_handles_refund_pending_split() {
+        global $wpdb;
+        $wpdb->results_data = [
+            [
+                'action_data' => json_encode([
+                    'transaction_id' => 'TXR',
+                    'amount' => 40,
+                    'items' => [
+                        [
+                            'ticket_id' => 7,
+                            'ticket_name' => 'General',
+                            'quantity' => 2,
+                            'refund_pending' => true,
+                            'refund_attendee' => [
+                                'first_name' => 'Ann',
+                                'last_name'  => 'A',
+                                'email'      => 'a@e.com'
+                            ],
+                            'attendees' => [
+                                [ 'first_name' => 'Bob', 'last_name' => 'B', 'email' => 'b@e.com' ]
+                            ]
+                        ]
+                    ]
+                ]),
+                'event_id'    => 9,
+                'name'        => 'Refund Event',
+                'page_id'     => 1,
+                'mainimageid' => 0,
+                'date'        => '2030-01-02',
+                'time'        => '08:00|10:00',
+                'address'     => '1 St -  - City - ST - 00000',
+                'type'        => 'paid',
+                'refundsavailable' => '1'
+            ]
+        ];
+
+        $events = tta_get_member_upcoming_events(1);
+        $this->assertCount(1, $events);
+        $items = $events[0]['items'];
+        $this->assertCount(2, $items);
+        $pending = array_values(array_filter($items, function($i){ return !empty($i['refund_pending']); }));
+        $this->assertCount(1, $pending);
+        $normal = array_values(array_filter($items, function($i){ return empty($i['refund_pending']); }));
+        $this->assertCount(1, $normal);
+        $this->assertSame('Bob', $normal[0]['attendees'][0]['first_name']);
     }
 
     public function test_get_member_past_events_queries_archive() {

--- a/app/public/wp-content/plugins/tta-management-plugin/tests/HelpersTest.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/tests/HelpersTest.php
@@ -215,6 +215,43 @@ class HelpersTest extends TestCase {
         $this->assertStringContainsString('wp_tta_memberhistory', $wpdb->last_query);
     }
 
+    public function test_get_member_upcoming_events_splits_multi_attendees() {
+        global $wpdb;
+        $wpdb->results_data = [
+            [
+                'action_data' => json_encode([
+                    'transaction_id' => 'TXS',
+                    'amount' => 40,
+                    'items' => [
+                        [
+                            'ticket_id' => 7,
+                            'ticket_name' => 'General',
+                            'quantity' => 2,
+                            'attendees' => [
+                                [ 'first_name' => 'Ann',  'last_name' => 'A', 'email' => 'a@e.com' ],
+                                [ 'first_name' => 'Bob',  'last_name' => 'B', 'email' => 'b@e.com' ],
+                            ]
+                        ]
+                    ]
+                ]),
+                'event_id'    => 9,
+                'name'        => 'Split Event',
+                'page_id'     => 1,
+                'mainimageid' => 0,
+                'date'        => '2030-01-02',
+                'time'        => '08:00|10:00',
+                'address'     => '1 St -  - City - ST - 00000',
+                'type'        => 'paid',
+                'refundsavailable' => '1'
+            ]
+        ];
+        $events = tta_get_member_upcoming_events(1);
+        $this->assertCount(1, $events);
+        $this->assertCount(2, $events[0]['items']);
+        $this->assertSame('Ann', $events[0]['items'][0]['attendees'][0]['first_name']);
+        $this->assertSame('Bob', $events[0]['items'][1]['attendees'][0]['first_name']);
+    }
+
     public function test_get_member_past_events_queries_archive() {
         global $wpdb;
         $wpdb->results_data = [

--- a/docs/MemberDashboard.md
+++ b/docs/MemberDashboard.md
@@ -19,6 +19,7 @@ shows:
 - The total amount paid for the transaction
 - Each ticket purchased with the attendee names and emails and its individual price
 - A separate link for each ticket to request a refund (paid events) or cancel attendance (free events) which reveals a small form. When multiple of the same ticket type are purchased they appear as individual entries so refunds can be requested per attendee
+- If a refund is pending for one attendee the entry remains with a pending note while any remaining attendees still appear separately with their own refund links
 - Submitting the form shows a spinner and records a `refund_request` entry in `tta_memberhistory`. The attendee is removed immediately. The refund is processed automatically once another member buys that ticket, otherwise the request expires two hours before the event. Administrators can review pending requests on the **TTA Refund Requests** admin page where they remain listed until processed.
 
 Events are loaded chronologically and the layout supports any number of events.

--- a/docs/MemberDashboard.md
+++ b/docs/MemberDashboard.md
@@ -18,7 +18,7 @@ shows:
 - Event location
 - The total amount paid for the transaction
 - Each ticket purchased with the attendee names and emails and its individual price
-- A separate link for each ticket to request a refund (paid events) or cancel attendance (free events) which reveals a small form
+- A separate link for each ticket to request a refund (paid events) or cancel attendance (free events) which reveals a small form. When multiple of the same ticket type are purchased they appear as individual entries so refunds can be requested per attendee
 - Submitting the form shows a spinner and records a `refund_request` entry in `tta_memberhistory`. The attendee is removed immediately. The refund is processed automatically once another member buys that ticket, otherwise the request expires two hours before the event. Administrators can review pending requests on the **TTA Refund Requests** admin page where they remain listed until processed.
 
 Events are loaded chronologically and the layout supports any number of events.


### PR DESCRIPTION
## Summary
- split attendee items when more than one ticket of the same type is purchased
- document that duplicate tickets show separate refund links
- test splitting logic in `tta_get_member_upcoming_events`

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_686f135a12bc83209abb718af059705b