### PR TITLE
Fix refund request mapping to correct attendee

### DIFF
--- a/app/public/wp-content/plugins/tta-management-plugin/assets/js/frontend/member-dashboard.js
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/js/frontend/member-dashboard.js
@@ -223,6 +223,7 @@ jQuery(function($){
         $form = $btn.closest('.tta-refund-form'),
         tx    = $btn.data('tx'),
         ticket = $btn.data('ticket'),
+        attendee = $btn.data('attendee'),
         reason= $form.find('textarea').val(),
         eventId = $form.data('event'),
         $spin = $form.find('.tta-admin-progress-spinner-svg'),
@@ -239,6 +240,7 @@ jQuery(function($){
       transaction_id: tx,
       event_id: eventId,
       ticket_id: ticket,
+      attendee_id: attendee,
       reason: reason
     }, function(res){
       var delay = Math.max(0, 5000 - (Date.now()-start));

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/ajax/handlers/class-ajax-refund.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/ajax/handlers/class-ajax-refund.php
@@ -12,11 +12,12 @@ class TTA_Ajax_Refund {
         if ( ! is_user_logged_in() ) {
             wp_send_json_error( [ 'message' => __( 'You must be logged in.', 'tta' ) ] );
         }
-        $tx_id    = tta_sanitize_text_field( $_POST['transaction_id'] ?? '' );
-        $event_id = intval( $_POST['event_id'] ?? 0 );
-        $ticket_id= intval( $_POST['ticket_id'] ?? 0 );
+        $tx_id     = tta_sanitize_text_field( $_POST['transaction_id'] ?? '' );
+        $event_id  = intval( $_POST['event_id'] ?? 0 );
+        $ticket_id = intval( $_POST['ticket_id'] ?? 0 );
+        $att_id    = intval( $_POST['attendee_id'] ?? 0 );
         $reason  = tta_sanitize_textarea_field( $_POST['reason'] ?? '' );
-        if ( ! $tx_id || ! $event_id ) {
+        if ( ! $tx_id || ! $event_id || ! $att_id ) {
             wp_send_json_error( [ 'message' => 'missing_data' ] );
         }
         global $wpdb;
@@ -28,7 +29,7 @@ class TTA_Ajax_Refund {
         }
 
         // Gather attendee details before cancelling.
-        $att         = tta_get_attendee_by_tx_ticket( $tx_id, $ticket_id );
+        $att         = tta_get_attendee_by_tx_ticket( $tx_id, $ticket_id, $att_id );
         $att_details = [];
         $amount      = 0;
         if ( $att ) {

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/views/tab-upcoming.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/views/tab-upcoming.php
@@ -33,6 +33,7 @@
             </div>
           </div>
           <?php foreach ( $ev['items'] as $it ) : ?>
+            <?php $first_att = reset( $it['attendees'] ); ?>
             <div class="tta-ticket-details">
               <strong><?php echo esc_html( $it['ticket_name'] ); ?> (<?php echo intval( $it['quantity'] ); ?>)</strong>
               <?php if ( isset( $it['final_price'] ) ) : ?>
@@ -61,7 +62,7 @@
               <?php if ( empty( $it['refund_pending'] ) ) : ?>
               <div class="tta-refund-wrapper">
                 <?php if ( $ev['amount'] > 0 ) : ?>
-                  <a href="#" class="tta-refund-link" data-tx="<?php echo esc_attr( $ev['transaction_id'] ); ?>" data-event="<?php echo esc_attr( $ev['event_id'] ); ?>" data-ticket="<?php echo esc_attr( $it['ticket_id'] ); ?>">
+                  <a href="#" class="tta-refund-link" data-tx="<?php echo esc_attr( $ev['transaction_id'] ); ?>" data-event="<?php echo esc_attr( $ev['event_id'] ); ?>" data-ticket="<?php echo esc_attr( $it['ticket_id'] ); ?>" data-attendee="<?php echo esc_attr( $first_att['id'] ?? '' ); ?>">
                     <?php esc_html_e( 'Cancel Attendance & Request a Refund', 'tta' ); ?>
                   </a>
                 <?php else : ?>
@@ -69,13 +70,13 @@
                     <?php esc_html_e( 'Cancel Attendance', 'tta' ); ?>
                   </a>
                 <?php endif; ?>
-                <form class="tta-refund-form" data-tx="<?php echo esc_attr( $ev['transaction_id'] ); ?>" data-event="<?php echo esc_attr( $ev['event_id'] ); ?>" data-ticket="<?php echo esc_attr( $it['ticket_id'] ); ?>">
+                <form class="tta-refund-form" data-tx="<?php echo esc_attr( $ev['transaction_id'] ); ?>" data-event="<?php echo esc_attr( $ev['event_id'] ); ?>" data-ticket="<?php echo esc_attr( $it['ticket_id'] ); ?>" data-attendee="<?php echo esc_attr( $first_att['id'] ?? '' ); ?>">
                   <label for="refund-<?php echo esc_attr( $ev['transaction_id'] . '-' . $it['ticket_id'] ); ?>">
                     <?php esc_html_e( 'Refund Request Details', 'tta' ); ?>
                   </label>
                   <span class="description"><?php esc_html_e( 'tell us why you\'re requesting a refund', 'tta' ); ?></span>
                   <textarea id="refund-<?php echo esc_attr( $ev['transaction_id'] . '-' . $it['ticket_id'] ); ?>" placeholder="<?php esc_attr_e( 'tell us why you\'re requesting a refund', 'tta' ); ?>"></textarea>
-                  <button type="button" class="tta-refund-submit" data-tx="<?php echo esc_attr( $ev['transaction_id'] ); ?>" data-ticket="<?php echo esc_attr( $it['ticket_id'] ); ?>">
+                  <button type="button" class="tta-refund-submit" data-tx="<?php echo esc_attr( $ev['transaction_id'] ); ?>" data-ticket="<?php echo esc_attr( $it['ticket_id'] ); ?>" data-attendee="<?php echo esc_attr( $first_att['id'] ?? '' ); ?>">
                     <?php echo $ev['amount'] > 0 ? esc_html__( 'Cancel Attendance & Request a Refund', 'tta' ) : esc_html__( 'Cancel Attendance', 'tta' ); ?>
                   </button>
                   <span class="tta-progress-spinner">

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
@@ -2181,9 +2181,10 @@ function tta_get_ticket_pending_refund_attendees( $ticket_id, $event_id ) {
  *
  * @param string $gateway_tx_id Gateway transaction ID.
  * @param int    $ticket_id     Ticket ID.
+ * @param int    $attendee_id   Optional attendee ID for transactions with multiple of the same ticket.
  * @return array|null Attendee row.
- */
-function tta_get_attendee_by_tx_ticket( $gateway_tx_id, $ticket_id ) {
+*/
+function tta_get_attendee_by_tx_ticket( $gateway_tx_id, $ticket_id, $attendee_id = 0 ) {
     global $wpdb;
     $att_table = $wpdb->prefix . 'tta_attendees';
     $tx_table  = $wpdb->prefix . 'tta_transactions';
@@ -2196,7 +2197,11 @@ function tta_get_attendee_by_tx_ticket( $gateway_tx_id, $ticket_id ) {
     if ( ! $tx_row ) {
         return null;
     }
-    $att = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$att_table} WHERE transaction_id = %d AND ticket_id = %d LIMIT 1", intval( $tx_row['id'] ), $ticket_id ), ARRAY_A );
+    if ( $attendee_id ) {
+        $att = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$att_table} WHERE id = %d AND transaction_id = %d AND ticket_id = %d LIMIT 1", $attendee_id, intval( $tx_row['id'] ), $ticket_id ), ARRAY_A );
+    } else {
+        $att = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$att_table} WHERE transaction_id = %d AND ticket_id = %d LIMIT 1", intval( $tx_row['id'] ), $ticket_id ), ARRAY_A );
+    }
     return $att ?: null;
 }
 

--- a/docs/MemberDashboard.md
+++ b/docs/MemberDashboard.md
@@ -19,6 +19,7 @@ shows:
 - The total amount paid for the transaction
 - Each ticket purchased with the attendee names and emails and its individual price
 - A separate link for each ticket to request a refund (paid events) or cancel attendance (free events) which reveals a small form. When multiple of the same ticket type are purchased they appear as individual entries so refunds can be requested per attendee
+- Each refund link now carries the attendee ID so the correct person is removed when multiple identical tickets exist in one transaction
 - If a refund is pending for one attendee the entry remains with a pending note while any remaining attendees still appear separately with their own refund links
 - Submitting the form shows a spinner and records a `refund_request` entry in `tta_memberhistory`. The attendee is removed immediately. The refund is processed automatically once another member buys that ticket, otherwise the request expires two hours before the event. Administrators can review pending requests on the **TTA Refund Requests** admin page where they remain listed until processed.
 


### PR DESCRIPTION
## Summary
- ensure attendee ID is passed with refund request links
- handle attendee ID in AJAX refund handler and helpers
- document attendee ID logic for refund links

## Testing
- `composer install`
- `./vendor/bin/phpunit -c phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_686fa63fad1c8320bd02cd8e42c3207e