### PR TITLE
Fix duplicate emails after checkout

### DIFF
--- a/app/public/wp-content/plugins/tta-management-plugin/includes/email/class-email-handler.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/email/class-email-handler.php
@@ -56,6 +56,7 @@ class TTA_Email_Handler {
             if ( empty( $event ) ) {
                 continue;
             }
+
             $attendees = [];
             foreach ( $ev_items as $it ) {
                 foreach ( (array) ( $it['attendees'] ?? [] ) as $att ) {
@@ -63,15 +64,34 @@ class TTA_Email_Handler {
                 }
             }
 
-            $tokens = $this->build_tokens( $event, $context, $attendees );
-            $subject = strtr( $tpl['email_subject'], $tokens );
-            $body    = nl2br( strtr( $tpl['email_body'], $tokens ) );
+            $headers   = [ 'Content-Type: text/html; charset=UTF-8' ];
+            $tokens    = $this->build_tokens( $event, $context, $attendees );
 
-            $recipients = array_merge( [ $context['user_email'] ], array_column( $attendees, 'email' ) );
-            $recipients = array_values( array_unique( array_filter( array_map( 'sanitize_email', $recipients ) ) ) );
-            $headers    = [ 'Content-Type: text/html; charset=UTF-8' ];
-            foreach ( $recipients as $to ) {
-                wp_mail( $to, $subject, $body, $headers );
+            $member_email = sanitize_email( $context['user_email'] );
+            if ( $member_email ) {
+                $subject = strtr( $tpl['email_subject'], $tokens );
+                $body    = nl2br( strtr( $tpl['email_body'], $tokens ) );
+                wp_mail( $member_email, $subject, $body, $headers );
+            }
+
+            $sent = $member_email ? [ $member_email => true ] : [];
+            foreach ( $attendees as $att ) {
+                $email = sanitize_email( $att['email'] ?? '' );
+                if ( ! $email || isset( $sent[ $email ] ) ) {
+                    continue;
+                }
+
+                $sent[ $email ] = true;
+
+                $per_tokens = $tokens;
+                $per_tokens['{attendee_first_name}'] = sanitize_text_field( $att['first_name'] ?? '' );
+                $per_tokens['{attendee_last_name}']  = sanitize_text_field( $att['last_name'] ?? '' );
+                $per_tokens['{attendee_email}']      = $email;
+                $per_tokens['{attendee_phone}']      = sanitize_text_field( $att['phone'] ?? '' );
+
+                $subject = strtr( $tpl['email_subject'], $per_tokens );
+                $body    = nl2br( strtr( $tpl['email_body'], $per_tokens ) );
+                wp_mail( $email, $subject, $body, $headers );
             }
         }
     }

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/email/class-email-handler.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/email/class-email-handler.php
@@ -67,13 +67,11 @@ class TTA_Email_Handler {
             $subject = strtr( $tpl['email_subject'], $tokens );
             $body    = nl2br( strtr( $tpl['email_body'], $tokens ) );
 
-            $recipients = array_unique( array_merge( [ $context['user_email'] ], array_column( $attendees, 'email' ) ) );
+            $recipients = array_merge( [ $context['user_email'] ], array_column( $attendees, 'email' ) );
+            $recipients = array_values( array_unique( array_filter( array_map( 'sanitize_email', $recipients ) ) ) );
             $headers    = [ 'Content-Type: text/html; charset=UTF-8' ];
             foreach ( $recipients as $to ) {
-                $to = sanitize_email( $to );
-                if ( $to ) {
-                    wp_mail( $to, $subject, $body, $headers );
-                }
+                wp_mail( $to, $subject, $body, $headers );
             }
         }
     }

--- a/docs/EmailSMS.md
+++ b/docs/EmailSMS.md
@@ -125,5 +125,5 @@ database values into the human-friendly strings shown by `{event_date}` and
 
 ## Email Delivery
 
-All outgoing messages are dispatched by the `TTA_Email_Handler` class. The handler is loaded on plugin init and is responsible for reading the templates saved on the **Email & SMS** page. After a transaction is recorded, `send_purchase_emails()` groups the purchased items by event and emails the **Successful Event Purchase** template. The purchasing member and every attendee receive their own copy, with one message sent for each event in the cart.
-Recipient addresses are sanitized and deduplicated before sending to prevent accidental duplicate emails when the same address is entered multiple times.
+All outgoing messages are dispatched by the `TTA_Email_Handler` class. The handler is loaded on plugin init and is responsible for reading the templates saved on the **Email & SMS** page. After a transaction is recorded, `send_purchase_emails()` groups the purchased items by event and emails the **Successful Event Purchase** template. The purchasing member receives a summary email while each attendee gets a personalized copy with their own `{attendee_first_name}` and related tokens.
+Recipient addresses are sanitized and deduplicated before sending to prevent accidental duplicates when the same address is entered more than once.

--- a/docs/EmailSMS.md
+++ b/docs/EmailSMS.md
@@ -126,3 +126,4 @@ database values into the human-friendly strings shown by `{event_date}` and
 ## Email Delivery
 
 All outgoing messages are dispatched by the `TTA_Email_Handler` class. The handler is loaded on plugin init and is responsible for reading the templates saved on the **Email & SMS** page. After a transaction is recorded, `send_purchase_emails()` groups the purchased items by event and emails the **Successful Event Purchase** template. The purchasing member and every attendee receive their own copy, with one message sent for each event in the cart.
+Recipient addresses are sanitized and deduplicated before sending to prevent accidental duplicate emails when the same address is entered multiple times.


### PR DESCRIPTION
## Summary
- deduplicate recipient emails before sending purchase confirmation
- document email deduplication behavior

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_686fe49c40788320b14699aa91659fe8