### PR TITLE
Fix duplicate purchase email notifications

### DIFF
--- a/app/public/wp-content/plugins/tta-management-plugin/includes/email/class-email-handler.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/email/class-email-handler.php
@@ -65,20 +65,22 @@ class TTA_Email_Handler {
             }
 
             $headers = [ 'Content-Type: text/html; charset=UTF-8' ];
+            $sent    = [];
 
             // Send email to purchasing member using default attendee order.
             $base_tokens = $this->build_tokens( $event, $context, $attendees );
             $subject     = strtr( $tpl['email_subject'], $base_tokens );
             $body        = nl2br( strtr( $tpl['email_body'], $base_tokens ) );
             $to          = sanitize_email( $context['user_email'] );
-            if ( $to ) {
+            if ( $to && ! in_array( $to, $sent, true ) ) {
                 wp_mail( $to, $subject, $body, $headers );
+                $sent[] = $to;
             }
 
             // Send personalized email to each attendee.
             foreach ( $attendees as $index => $att ) {
                 $recipient = sanitize_email( $att['email'] ?? '' );
-                if ( ! $recipient ) {
+                if ( ! $recipient || in_array( $recipient, $sent, true ) ) {
                     continue;
                 }
 
@@ -93,6 +95,7 @@ class TTA_Email_Handler {
                 $subject = strtr( $tpl['email_subject'], $tokens );
                 $body    = nl2br( strtr( $tpl['email_body'], $tokens ) );
                 wp_mail( $recipient, $subject, $body, $headers );
+                $sent[] = $recipient;
             }
         }
     }

--- a/docs/EmailSMS.md
+++ b/docs/EmailSMS.md
@@ -128,4 +128,4 @@ database values into the human-friendly strings shown by `{event_date}` and
 
 ## Email Delivery
 
-All outgoing messages are dispatched by the `TTA_Email_Handler` class. The handler is loaded on plugin init and is responsible for reading the templates saved on the **Email & SMS** page. After a transaction is recorded, `send_purchase_emails()` groups the purchased items by event and emails the **Successful Event Purchase** template. The purchasing member receives one email and each attendee gets a personalized copy where tokens like `{attendee_first_name}` reflect their own information.
+All outgoing messages are dispatched by the `TTA_Email_Handler` class. The handler is loaded on plugin init and is responsible for reading the templates saved on the **Email & SMS** page. After a transaction is recorded, `send_purchase_emails()` groups the purchased items by event and emails the **Successful Event Purchase** template. The purchasing member receives one email and each attendee gets a personalized copy where tokens like `{attendee_first_name}` reflect their own information. Duplicate addresses are skipped so each email address only receives one message.


### PR DESCRIPTION
## Summary
- avoid sending purchase confirmation multiple times to the same address
- clarify email delivery behavior in docs

## Testing
- `composer install`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_687000fc64d4832085e417ce9660e3c0