### PR TITLE
Implement refund ticket pool

### DIFF
--- a/app/public/wp-content/plugins/tta-management-plugin/includes/ajax/handlers/class-ajax-refund.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/ajax/handlers/class-ajax-refund.php
@@ -43,7 +43,7 @@ class TTA_Ajax_Refund {
             if ( $tx_row ) {
                 $amount = tta_get_ticket_price_from_transaction( $tx_row, $ticket_id );
             }
-            tta_cancel_attendance_internal( intval( $att['id'] ) );
+            tta_cancel_attendance_internal( intval( $att['id'] ), false );
         }
 
         $action_data = [

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/cart/class-cart.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/cart/class-cart.php
@@ -127,6 +127,10 @@ class TTA_Cart {
     $this->ensure_cart( true );
     $ticket_id = intval( $ticket_id );
     $qty       = intval( $qty );
+    $event_ute = $this->wpdb->get_var( $this->wpdb->prepare( "SELECT event_ute_id FROM {$this->wpdb->prefix}tta_tickets WHERE id = %d", $ticket_id ) );
+    if ( $event_ute ) {
+      tta_release_refund_tickets( $event_ute );
+    }
     $existing_qty = (int) $this->wpdb->get_var(
       $this->wpdb->prepare(
         "SELECT quantity FROM {$this->items_table} WHERE cart_id = %d AND ticket_id = %d",

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/templates/event-page-template.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/templates/event-page-template.php
@@ -60,6 +60,8 @@ if ( ! $event ) {
 
 $has_waitlist = ( '1' === (string) ( $event['waitlistavailable'] ?? '0' ) );
 
+tta_release_refund_tickets( $event['ute_id'] );
+
 // ───────────────
 // 3) Fetch this event’s ticket types
 // ───────────────

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
@@ -2289,6 +2289,17 @@ function tta_get_ticket_pending_refund_attendees( $ticket_id, $event_id ) {
 }
 
 /**
+ * Get the count of pending refund requests for a ticket.
+ *
+ * @param int $ticket_id Ticket ID.
+ * @param int $event_id  Event ID.
+ * @return int
+ */
+function tta_get_ticket_refund_pool_count( $ticket_id, $event_id ) {
+    return count( tta_get_ticket_pending_refund_attendees( $ticket_id, $event_id ) );
+}
+
+/**
  * Lookup an attendee row by gateway transaction ID and ticket ID.
  *
  * @param string $gateway_tx_id Gateway transaction ID.
@@ -2320,9 +2331,10 @@ function tta_get_attendee_by_tx_ticket( $gateway_tx_id, $ticket_id, $attendee_id
 /**
  * Cancel an attendee without Ajax context.
  *
- * @param int $attendee_id Attendee ID.
+ * @param int  $attendee_id     Attendee ID.
+ * @param bool $update_inventory Whether to increment ticket inventory.
  */
-function tta_cancel_attendance_internal( $attendee_id ) {
+function tta_cancel_attendance_internal( $attendee_id, $update_inventory = true ) {
     global $wpdb;
     $att_table   = $wpdb->prefix . 'tta_attendees';
     $ticket_table = $wpdb->prefix . 'tta_tickets';
@@ -2374,7 +2386,9 @@ function tta_cancel_attendance_internal( $attendee_id ) {
         $after   = $current + 1;
         $should_notify = ( $current <= 0 && $after > 0 );
 
-        $wpdb->query( $wpdb->prepare( "UPDATE {$ticket_table} SET ticketlimit = ticketlimit + 1 WHERE id = %d", intval( $att['ticket_id'] ) ) );
+        if ( $update_inventory ) {
+            $wpdb->query( $wpdb->prepare( "UPDATE {$ticket_table} SET ticketlimit = ticketlimit + 1 WHERE id = %d", intval( $att['ticket_id'] ) ) );
+        }
         if ( ! empty( $ticket['event_ute_id'] ) ) {
             TTA_Cache::delete( 'tickets_' . $ticket['event_ute_id'] );
         }
@@ -2382,7 +2396,7 @@ function tta_cancel_attendance_internal( $attendee_id ) {
 
     TTA_Cache::flush();
 
-    if ( $should_notify ) {
+    if ( $update_inventory && $should_notify ) {
         tta_notify_waitlist_ticket_available( intval( $att['ticket_id'] ) );
     }
 }
@@ -2524,6 +2538,24 @@ function tta_get_event_ute_id( $event_id ) {
     }
     $ute = $wpdb->get_var( $wpdb->prepare( "SELECT ute_id FROM {$events_table} WHERE id = %d UNION SELECT ute_id FROM {$archive_table} WHERE id = %d LIMIT 1", $event_id, $event_id ) );
     return $ute ? sanitize_text_field( $ute ) : '';
+}
+
+/**
+ * Retrieve an event ID from a ute_id.
+ *
+ * @param string $event_ute_id Event ute_id.
+ * @return int Event ID or 0.
+ */
+function tta_get_event_id_by_ute( $event_ute_id ) {
+    global $wpdb;
+    $events_table  = $wpdb->prefix . 'tta_events';
+    $archive_table = $wpdb->prefix . 'tta_events_archive';
+    $event_ute_id  = sanitize_text_field( $event_ute_id );
+    if ( '' === $event_ute_id ) {
+        return 0;
+    }
+    $id = $wpdb->get_var( $wpdb->prepare( "SELECT id FROM {$events_table} WHERE ute_id = %s UNION SELECT id FROM {$archive_table} WHERE ute_id = %s LIMIT 1", $event_ute_id, $event_ute_id ) );
+    return $id ? intval( $id ) : 0;
 }
 
 /**
@@ -3321,6 +3353,51 @@ function tta_admin_preview_image( $attachment_id, array $size, array $attrs = []
         $height,
         $attr_str
     );
+}
+
+/**
+ * Release tickets from the refund pool when an event sells out.
+ *
+ * @param string $event_ute_id Event ute_id.
+ */
+function tta_release_refund_tickets( $event_ute_id ) {
+    global $wpdb;
+    $event_ute_id = sanitize_text_field( $event_ute_id );
+    if ( '' === $event_ute_id ) {
+        return;
+    }
+    if ( ! is_object( $wpdb ) || ! method_exists( $wpdb, 'get_results' ) ) {
+        return;
+    }
+    $events_table  = $wpdb->prefix . 'tta_events';
+    $tickets_table = $wpdb->prefix . 'tta_tickets';
+
+    $event_id = tta_get_event_id_by_ute( $event_ute_id );
+    if ( ! $event_id ) {
+        return;
+    }
+
+    $tickets = $wpdb->get_results(
+        $wpdb->prepare(
+            "SELECT id, ticketlimit FROM {$tickets_table} WHERE event_ute_id = %s",
+            $event_ute_id
+        ),
+        ARRAY_A
+    );
+
+    foreach ( $tickets as $t ) {
+        $tid   = intval( $t['id'] );
+        $limit = intval( $t['ticketlimit'] );
+        if ( $limit > 0 ) {
+            continue;
+        }
+        $pool = tta_get_ticket_refund_pool_count( $tid, $event_id );
+        if ( $pool > 0 ) {
+            $wpdb->query( $wpdb->prepare( "UPDATE {$tickets_table} SET ticketlimit = ticketlimit + %d WHERE id = %d", $pool, $tid ) );
+            TTA_Cache::delete( 'tickets_' . $event_ute_id );
+            tta_notify_waitlist_ticket_available( $tid );
+        }
+    }
 }
 
 /**

--- a/docs/RefundRequestsAdmin.md
+++ b/docs/RefundRequestsAdmin.md
@@ -4,5 +4,5 @@ The **TTA Refund Requests** admin screen lists every refund submitted from a mem
 
 If a member purchased multiple tickets in the same transaction the request specifies the ticket ID so only the relevant attendee(s) appear in the table.
 
-After a refund and cancellation the ticket inventory is increased automatically so other members may purchase the newly available spot. Clicking **Refund Now** processes the refund immediately using Authorize.Net and removes the pending request so the ticket will not be refunded a second time when another purchase occurs.
-Processed requests disappear from the list once the refund is issued or the request expires. When a refund request is submitted the attendee is cancelled immediately so the seat becomes available. The refund is automatically processed once another member purchases the ticket. Any requests still pending within two hours of the event are removed without a refund.
+After a refund request the attendee is removed but the ticket is held in a refund pool rather than adding back to inventory. Tickets from this pool are only released once all regular tickets sell out. Clicking **Refund Now** processes the refund immediately and returns the seat to the normal inventory.
+Processed requests disappear from the list once the refund is issued or the request expires. Pending requests are automatically refunded when a pooled ticket is purchased. Any requests still pending within two hours of the event are removed without a refund.


### PR DESCRIPTION
## Summary
- avoid increasing ticket inventory when member requests a refund
- add helper to release refund pool tickets once an event sells out
- update event page and cart logic to make use of the refund pool
- document refund pool behaviour

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6870f4b80b8c8320a85ba1ef273c85e3