### PR TITLE
Add email indexes to attendee tables

### DIFF
--- a/app/public/wp-content/plugins/tta-management-plugin/includes/class-db-setup.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/class-db-setup.php
@@ -315,7 +315,8 @@ class TTA_DB_Setup {
             status          ENUM('pending','checked_in','no_show') DEFAULT 'pending',
             PRIMARY KEY     (id),
             KEY transaction_idx (transaction_id),
-            KEY ticket_idx      (ticket_id)
+            KEY ticket_idx      (ticket_id),
+            KEY email_idx (email)
         ) $charset_collate";
 
         // ─────────────────────────────────────────────────────────────────
@@ -337,7 +338,8 @@ class TTA_DB_Setup {
             status          ENUM('pending','checked_in','no_show') DEFAULT 'pending',
             PRIMARY KEY     (id),
             KEY transaction_idx (transaction_id),
-            KEY ticket_idx      (ticket_id)
+            KEY ticket_idx      (ticket_id),
+            KEY email_idx (email)
         ) $charset_collate";
 
         // Run dbDelta on each statement

--- a/app/public/wp-content/plugins/tta-management-plugin/tests/DbSetupTest.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/tests/DbSetupTest.php
@@ -46,6 +46,7 @@ class DbSetupTest extends TestCase {
         $this->assertStringContainsString('KEY date_idx (date)', $sql);
         $this->assertStringContainsString('KEY expires_at_idx (expires_at)', $sql);
         $this->assertStringContainsString('KEY name_idx (last_name, first_name)', $sql);
+        $this->assertStringContainsString('KEY email_idx (email)', $sql);
     }
 
     public function test_maybe_upgrade_runs_install_when_version_differs() {

--- a/app/public/wp-content/plugins/tta-management-plugin/trying-to-adult-management-plugin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/trying-to-adult-management-plugin.php
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 define( 'TTA_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TTA_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'TTA_PLUGIN_VERSION', '0.4.2' );
-define( 'TTA_DB_VERSION', '1.9.0' );
+define( 'TTA_DB_VERSION', '1.10.0' );
 define( 'TTA_BASIC_MEMBERSHIP_PRICE', 5.00 );
 define( 'TTA_PREMIUM_MEMBERSHIP_PRICE', 10.00 );
 define( 'TTA_BASIC_SUBSCRIPTION_NAME', 'Trying to Adult Basic Membership' );

--- a/docs/DevelopmentSQL.md
+++ b/docs/DevelopmentSQL.md
@@ -259,3 +259,15 @@ Version 1.4.0 adds a `subscription_status` column to `tta_members` which stores 
 ALTER TABLE `wp_j9bzlz98u3_tta_members`
   ADD COLUMN `subscription_status` ENUM('active','cancelled') DEFAULT 'active' AFTER `subscription_id`;
 ```
+
+## Add attendee email indexes
+
+Version 1.10.0 adds an index on the `email` column of both `tta_attendees` and `tta_attendees_archive` tables.
+This improves lookup performance. Existing installs update automatically, or you can run:
+
+```sql
+ALTER TABLE `wp_j9bzlz98u3_tta_attendees`
+  ADD KEY `email_idx` (`email`);
+ALTER TABLE `wp_j9bzlz98u3_tta_attendees_archive`
+  ADD KEY `email_idx` (`email`);
+```


### PR DESCRIPTION
## Summary
- add an `email_idx` index for attendees tables
- bump database version constant
- document new SQL changes
- expect new email index in DbSetupTest

## Testing
- `composer install`
- `vendor/bin/phpunit -c phpunit.xml --filter DbSetupTest`
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: hangs at 95%)*

------
https://chatgpt.com/codex/tasks/task_e_68779195aa308320901ee2e106f87ad4