### PR TITLE
Fix address helpers to handle street hyphens

### DIFF
--- a/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
@@ -1444,7 +1444,8 @@ function tta_user_had_membership( $wp_user_id ) {
  * @return string Formatted address.
  */
 function tta_format_address( $raw ) {
-    $parts  = preg_split( '/\s*[-–]\s*/u', $raw );
+    $raw    = trim( $raw );
+    $parts  = preg_split( '/\s[-–]\s/u', $raw );
     $street = trim( $parts[0] ?? '' );
     $addr2  = trim( $parts[1] ?? '' );
     $city   = trim( $parts[2] ?? '' );
@@ -1468,7 +1469,8 @@ function tta_format_address( $raw ) {
  * @return array{street:string,address2:string,city:string,state:string,zip:string}
  */
 function tta_parse_address( $raw ) {
-    $parts = preg_split( '/\s*[-–]\s*/u', $raw );
+    $raw   = trim( $raw );
+    $parts = preg_split( '/\s[-–]\s/u', $raw );
     return [
         'street'   => trim( $parts[0] ?? '' ),
         'address2' => trim( $parts[1] ?? '' ),

--- a/app/public/wp-content/plugins/tta-management-plugin/tests/HelpersTest.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/tests/HelpersTest.php
@@ -553,6 +553,24 @@ class HelpersTest extends TestCase {
         $out = tta_format_event_datetime('2025-07-19', '18:00|');
         $this->assertSame('Saturday July 19, 2025 - 6:00 PM', $out);
     }
+
+    public function test_parse_address_preserves_hyphenated_street() {
+        require_once __DIR__ . '/../includes/helpers.php';
+        $raw = '1234 E-State St - Apt A - Richmond - VA - 23231';
+        $parts = tta_parse_address($raw);
+        $this->assertSame('1234 E-State St', $parts['street']);
+        $this->assertSame('Apt A', $parts['address2']);
+        $this->assertSame('Richmond', $parts['city']);
+        $this->assertSame('VA', $parts['state']);
+        $this->assertSame('23231', $parts['zip']);
+    }
+
+    public function test_format_address_preserves_hyphenated_street() {
+        require_once __DIR__ . '/../includes/helpers.php';
+        $raw = '1234 E-State St -  - Richmond - VA - 23231';
+        $formatted = tta_format_address($raw);
+        $this->assertSame('1234 E-State St Richmond, VA 23231', $formatted);
+    }
     public function test_get_member_waitlist_events_returns_entries() {
         global $wpdb;
         $this->wpdb->results_calls = 0;

--- a/docs/AddressHelpers.md
+++ b/docs/AddressHelpers.md
@@ -6,7 +6,7 @@ The plugin stores both event and member addresses as a single string using dashe
 Street – Address 2 – City – State – ZIP
 ```
 
-Earlier sample data used a normal hyphen (`-`) while newer forms output an en dash (`–`). To ensure older rows continue to load, the new helper `tta_parse_address()` splits on either character and trims whitespace. It returns an associative array with keys `street`, `address2`, `city`, `state` and `zip`.
+Earlier sample data used a normal hyphen (`-`) while newer forms output an en dash (`–`). Each delimiter is wrapped in spaces (for example `Street - City`). The helper `tta_parse_address()` splits on these spaced dashes so older rows continue to load and hyphenated street names remain intact. It returns an associative array with keys `street`, `address2`, `city`, `state` and `zip`.
 
 Use this helper whenever an address needs to be broken into separate fields. `tta_format_address()` remains available for displaying a one line version on the front‑end.
 `tta_format_address()` now outputs addresses separated with spaces rather than an en dash so emails and front‑end pages read more naturally.


### PR DESCRIPTION
## Summary
- prevent `tta_format_address()` and `tta_parse_address()` from splitting on hyphens inside street names
- document updated behaviour in AddressHelpers doc
- test address helpers with a hyphenated street name

## Testing
- `vendor/bin/phpunit --filter test_parse_address_preserves_hyphenated_street`
- `vendor/bin/phpunit --filter test_format_address_preserves_hyphenated_street`
- `vendor/bin/phpunit` *(fails: process hung near end)*

------
https://chatgpt.com/codex/tasks/task_e_68779494a3c8832091bb92c49645016b