### PR TITLE
Enable sorting on Member History admin list

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ If these constants are not defined, checkout will fail and an admin notice will 
 - [Membership Benefits](docs/MembershipBenefits.md)
 - [Member Dashboard](docs/MemberDashboard.md)
 - [Member History Admin](docs/MemberHistoryAdmin.md)
+- [Admin List Sorting Options](docs/AdminListSorting.md)
 - [TTA Refund Requests Admin](docs/RefundRequestsAdmin.md)
 - [TTA Ads Admin](docs/AdsAdmin.md)
 - [Event Check-In Page](docs/EventCheckInAdmin.md)

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/views/events-archive.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/views/events-archive.php
@@ -58,22 +58,28 @@ if ( $search ) {
 $per_page = 20;
 $paged    = isset( $_GET['paged'] ) ? max( 1, intval( $_GET['paged'] ) ) : 1;
 $offset   = ( $paged - 1 ) * $per_page;
+$orderby  = isset( $_GET['orderby'] ) ? sanitize_text_field( $_GET['orderby'] ) : 'date_desc';
 
 // Total count
 $total = $wpdb->get_var( "SELECT COUNT(*) FROM {$table} {$where}" );
 
 // Fetch events in desired order
-$sql = "
-    SELECT *
-      FROM {$table}
-      {$where}
- ORDER
-    BY
-      CASE WHEN `date` >= CURDATE() THEN 0 ELSE 1 END ASC,
-      CASE WHEN `date` >= CURDATE() THEN `date` ELSE NULL END ASC,
-      CASE WHEN `date` <  CURDATE() THEN `date` ELSE NULL END DESC
-    LIMIT %d, %d
-";
+switch ( $orderby ) {
+    case 'date_asc':
+        $order_sql = 'ORDER BY `date` ASC';
+        break;
+    case 'date_desc':
+        $order_sql = 'ORDER BY `date` DESC';
+        break;
+    case 'name':
+        $order_sql = 'ORDER BY name ASC';
+        break;
+    default:
+        $order_sql = 'ORDER BY `date` DESC';
+        break;
+}
+
+$sql = "SELECT * FROM {$table} {$where} {$order_sql} LIMIT %d, %d";
 $events = $wpdb->get_results(
     $wpdb->prepare( $sql, $offset, $per_page ),
     ARRAY_A
@@ -86,6 +92,11 @@ $events = $wpdb->get_results(
     <p class="search-box">
         <label for="event-search-input" class="screen-reader-text">Search Events:</label>
         <input type="search" id="event-search-input" name="s" value="<?php echo esc_attr( $search ); ?>">
+        <select name="orderby" onchange="this.form.submit()">
+            <option value="date_desc" <?php selected( $orderby, 'date_desc' ); ?>><?php esc_html_e( 'Newest First', 'tta' ); ?></option>
+            <option value="date_asc" <?php selected( $orderby, 'date_asc' ); ?>><?php esc_html_e( 'Oldest First', 'tta' ); ?></option>
+            <option value="name" <?php selected( $orderby, 'name' ); ?>><?php esc_html_e( 'Event Name', 'tta' ); ?></option>
+        </select>
         <button class="button" type="submit">Search Events</button>
     </p>
 </form>

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/views/events-archive.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/views/events-archive.php
@@ -58,7 +58,8 @@ if ( $search ) {
 $per_page = 20;
 $paged    = isset( $_GET['paged'] ) ? max( 1, intval( $_GET['paged'] ) ) : 1;
 $offset   = ( $paged - 1 ) * $per_page;
-$orderby  = isset( $_GET['orderby'] ) ? sanitize_text_field( $_GET['orderby'] ) : 'date_desc';
+$orderby_param = isset( $_GET['orderby'] ) ? sanitize_text_field( $_GET['orderby'] ) : '';
+$orderby       = $orderby_param ? $orderby_param : 'date_desc';
 
 // Total count
 $total = $wpdb->get_var( "SELECT COUNT(*) FROM {$table} {$where}" );
@@ -92,12 +93,14 @@ $events = $wpdb->get_results(
     <p class="search-box">
         <label for="event-search-input" class="screen-reader-text">Search Events:</label>
         <input type="search" id="event-search-input" name="s" value="<?php echo esc_attr( $search ); ?>">
-        <select name="orderby" onchange="this.form.submit()">
-            <option value="date_desc" <?php selected( $orderby, 'date_desc' ); ?>><?php esc_html_e( 'Newest First', 'tta' ); ?></option>
-            <option value="date_asc" <?php selected( $orderby, 'date_asc' ); ?>><?php esc_html_e( 'Oldest First', 'tta' ); ?></option>
-            <option value="name" <?php selected( $orderby, 'name' ); ?>><?php esc_html_e( 'Event Name', 'tta' ); ?></option>
-        </select>
         <button class="button" type="submit">Search Events</button>
+        <select name="orderby" onchange="this.form.submit()">
+            <option value="" disabled <?php selected( $orderby_param, '' ); ?>><?php esc_html_e( 'Sort By…', 'tta' ); ?></option>
+            <option value="date_desc" <?php selected( $orderby_param, 'date_desc' ); ?>><?php esc_html_e( 'Newest First', 'tta' ); ?></option>
+            <option value="date_asc" <?php selected( $orderby_param, 'date_asc' ); ?>><?php esc_html_e( 'Oldest First', 'tta' ); ?></option>
+            <option value="name" <?php selected( $orderby_param, 'name' ); ?>><?php esc_html_e( 'Event Name', 'tta' ); ?></option>
+        </select>
+        <a href="<?php echo esc_url( admin_url( 'admin.php?page=tta-events&tab=archive' ) ); ?>" class="button"><?php esc_html_e( 'Clear Sorting', 'tta' ); ?></a>
     </p>
 </form>
 
@@ -190,6 +193,8 @@ echo paginate_links( [
     'total'     => ceil( $total / $per_page ),
     'prev_text' => '&laquo;',
     'next_text' => '&raquo;',
+    'end_size'  => 1,
+    'mid_size'  => $paged === 1 ? 19 : 2,
 ] );
 echo '</div></div>';
 ?>

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/views/events-manage.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/views/events-manage.php
@@ -85,22 +85,33 @@ if ( $search ) {
 $per_page = 20;
 $paged    = isset( $_GET['paged'] ) ? max( 1, intval( $_GET['paged'] ) ) : 1;
 $offset   = ( $paged - 1 ) * $per_page;
+$orderby  = isset( $_GET['orderby'] ) ? sanitize_text_field( $_GET['orderby'] ) : 'upcoming';
 
 // Total count
 $total = $wpdb->get_var( "SELECT COUNT(*) FROM {$table} {$where}" );
 
 // Fetch events in desired order
-$sql = "
-    SELECT *
-      FROM {$table}
-      {$where}
- ORDER
+switch ( $orderby ) {
+    case 'date_asc':
+        $order_sql = 'ORDER BY `date` ASC';
+        break;
+    case 'date_desc':
+        $order_sql = 'ORDER BY `date` DESC';
+        break;
+    case 'name':
+        $order_sql = 'ORDER BY name ASC';
+        break;
+    case 'upcoming':
+    default:
+        $order_sql = 'ORDER
     BY
       CASE WHEN `date` >= CURDATE() THEN 0 ELSE 1 END ASC,
       CASE WHEN `date` >= CURDATE() THEN `date` ELSE NULL END ASC,
-      CASE WHEN `date` <  CURDATE() THEN `date` ELSE NULL END DESC
-    LIMIT %d, %d
-";
+      CASE WHEN `date` <  CURDATE() THEN `date` ELSE NULL END DESC';
+        break;
+}
+
+$sql = "SELECT * FROM {$table} {$where} {$order_sql} LIMIT %d, %d";
 $events = $wpdb->get_results(
     $wpdb->prepare( $sql, $offset, $per_page ),
     ARRAY_A
@@ -113,6 +124,12 @@ $events = $wpdb->get_results(
     <p class="search-box">
         <label for="event-search-input" class="screen-reader-text">Search Events:</label>
         <input type="search" id="event-search-input" name="s" value="<?php echo esc_attr( $search ); ?>">
+        <select name="orderby" onchange="this.form.submit()">
+            <option value="upcoming" <?php selected( $orderby, 'upcoming' ); ?>><?php esc_html_e( 'Upcoming First', 'tta' ); ?></option>
+            <option value="date_asc" <?php selected( $orderby, 'date_asc' ); ?>><?php esc_html_e( 'Date Ascending', 'tta' ); ?></option>
+            <option value="date_desc" <?php selected( $orderby, 'date_desc' ); ?>><?php esc_html_e( 'Date Descending', 'tta' ); ?></option>
+            <option value="name" <?php selected( $orderby, 'name' ); ?>><?php esc_html_e( 'Event Name', 'tta' ); ?></option>
+        </select>
         <button class="button" type="submit">Search Events</button>
     </p>
 </form>

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/views/events-manage.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/views/events-manage.php
@@ -85,7 +85,8 @@ if ( $search ) {
 $per_page = 20;
 $paged    = isset( $_GET['paged'] ) ? max( 1, intval( $_GET['paged'] ) ) : 1;
 $offset   = ( $paged - 1 ) * $per_page;
-$orderby  = isset( $_GET['orderby'] ) ? sanitize_text_field( $_GET['orderby'] ) : 'upcoming';
+$orderby_param = isset( $_GET['orderby'] ) ? sanitize_text_field( $_GET['orderby'] ) : '';
+$orderby       = $orderby_param ? $orderby_param : 'upcoming';
 
 // Total count
 $total = $wpdb->get_var( "SELECT COUNT(*) FROM {$table} {$where}" );
@@ -124,13 +125,15 @@ $events = $wpdb->get_results(
     <p class="search-box">
         <label for="event-search-input" class="screen-reader-text">Search Events:</label>
         <input type="search" id="event-search-input" name="s" value="<?php echo esc_attr( $search ); ?>">
-        <select name="orderby" onchange="this.form.submit()">
-            <option value="upcoming" <?php selected( $orderby, 'upcoming' ); ?>><?php esc_html_e( 'Upcoming First', 'tta' ); ?></option>
-            <option value="date_asc" <?php selected( $orderby, 'date_asc' ); ?>><?php esc_html_e( 'Date Ascending', 'tta' ); ?></option>
-            <option value="date_desc" <?php selected( $orderby, 'date_desc' ); ?>><?php esc_html_e( 'Date Descending', 'tta' ); ?></option>
-            <option value="name" <?php selected( $orderby, 'name' ); ?>><?php esc_html_e( 'Event Name', 'tta' ); ?></option>
-        </select>
         <button class="button" type="submit">Search Events</button>
+        <select name="orderby" onchange="this.form.submit()">
+            <option value="" disabled <?php selected( $orderby_param, '' ); ?>><?php esc_html_e( 'Sort By…', 'tta' ); ?></option>
+            <option value="upcoming" <?php selected( $orderby_param, 'upcoming' ); ?>><?php esc_html_e( 'Upcoming First', 'tta' ); ?></option>
+            <option value="date_asc" <?php selected( $orderby_param, 'date_asc' ); ?>><?php esc_html_e( 'Date Ascending', 'tta' ); ?></option>
+            <option value="date_desc" <?php selected( $orderby_param, 'date_desc' ); ?>><?php esc_html_e( 'Date Descending', 'tta' ); ?></option>
+            <option value="name" <?php selected( $orderby_param, 'name' ); ?>><?php esc_html_e( 'Event Name', 'tta' ); ?></option>
+        </select>
+        <a href="<?php echo esc_url( admin_url( 'admin.php?page=tta-events&tab=manage' ) ); ?>" class="button"><?php esc_html_e( 'Clear Sorting', 'tta' ); ?></a>
     </p>
 </form>
 
@@ -238,6 +241,8 @@ echo paginate_links( [
     'total'     => ceil( $total / $per_page ),
     'prev_text' => '&laquo;',
     'next_text' => '&raquo;',
+    'end_size'  => 1,
+    'mid_size'  => $paged === 1 ? 19 : 2,
 ] );
 echo '</div></div>';
 ?>

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/views/members-history.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/views/members-history.php
@@ -20,7 +20,8 @@ $members_table = $wpdb->prefix . 'tta_members';
 $per_page = 10;
 $page      = isset( $_GET['paged'] ) ? max( 1, intval( $_GET['paged'] ) ) : 1;
 $offset    = ( $page - 1 ) * $per_page;
-$orderby   = isset( $_GET['orderby'] ) ? sanitize_text_field( $_GET['orderby'] ) : 'joined';
+$orderby_param = isset( $_GET['orderby'] ) ? sanitize_text_field( $_GET['orderby'] ) : '';
+$orderby       = $orderby_param ? $orderby_param : 'joined';
 
 // Build the WHERE clause for searching:
 $where_sql   = '';
@@ -94,15 +95,17 @@ $total_pages   = ceil( $total_members / $per_page );
           value="<?php echo esc_attr( $_GET['s'] ?? '' ); ?>"
           placeholder="Search by first name, last name, or email…"
         >
-        <select name="orderby" id="tta-member-orderby" onchange="this.form.submit()">
-          <option value="joined" <?php selected( $orderby, 'joined' ); ?>><?php esc_html_e( 'Newest Joined', 'tta' ); ?></option>
-          <option value="length" <?php selected( $orderby, 'length' ); ?>><?php esc_html_e( 'Membership Length', 'tta' ); ?></option>
-          <option value="attended" <?php selected( $orderby, 'attended' ); ?>><?php esc_html_e( 'Events Attended', 'tta' ); ?></option>
-          <option value="spent" <?php selected( $orderby, 'spent' ); ?>><?php esc_html_e( 'Total Spent', 'tta' ); ?></option>
-          <option value="first" <?php selected( $orderby, 'first' ); ?>><?php esc_html_e( 'First Name', 'tta' ); ?></option>
-          <option value="last" <?php selected( $orderby, 'last' ); ?>><?php esc_html_e( 'Last Name', 'tta' ); ?></option>
-        </select>
         <button class="button" type="submit"><?php esc_html_e( 'Search Members', 'tta' ); ?></button>
+        <select name="orderby" id="tta-member-orderby" onchange="this.form.submit()">
+          <option value="" disabled <?php selected( $orderby_param, '' ); ?>><?php esc_html_e( 'Sort By…', 'tta' ); ?></option>
+          <option value="joined" <?php selected( $orderby_param, 'joined' ); ?>><?php esc_html_e( 'Newest Joined', 'tta' ); ?></option>
+          <option value="length" <?php selected( $orderby_param, 'length' ); ?>><?php esc_html_e( 'Membership Length', 'tta' ); ?></option>
+          <option value="attended" <?php selected( $orderby_param, 'attended' ); ?>><?php esc_html_e( 'Events Attended', 'tta' ); ?></option>
+          <option value="spent" <?php selected( $orderby_param, 'spent' ); ?>><?php esc_html_e( 'Total Spent', 'tta' ); ?></option>
+          <option value="first" <?php selected( $orderby_param, 'first' ); ?>><?php esc_html_e( 'First Name', 'tta' ); ?></option>
+          <option value="last" <?php selected( $orderby_param, 'last' ); ?>><?php esc_html_e( 'Last Name', 'tta' ); ?></option>
+        </select>
+        <a href="<?php echo esc_url( admin_url( 'admin.php?page=tta-members&tab=history' ) ); ?>" class="button"><?php esc_html_e( 'Clear Sorting', 'tta' ); ?></a>
       </p>
     </form>
 
@@ -178,14 +181,18 @@ $total_pages   = ceil( $total_members / $per_page );
         <div class="tablenav">
             <div class="tablenav-pages">
                 <?php
-                    echo paginate_links( [
+                    $pagination_args = [
                         'base'      => add_query_arg( 'paged', '%#%' ),
                         'format'    => '',
                         'prev_text' => '&laquo;',
                         'next_text' => '&raquo;',
                         'total'     => $total_pages,
                         'current'   => $page,
-                    ] );
+                        'end_size'  => 1,
+                        'mid_size'  => $page === 1 ? 19 : 2,
+                    ];
+
+                    echo paginate_links( $pagination_args );
                 ?>
             </div>
         </div>

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/views/members-history.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/views/members-history.php
@@ -20,6 +20,7 @@ $members_table = $wpdb->prefix . 'tta_members';
 $per_page = 10;
 $page      = isset( $_GET['paged'] ) ? max( 1, intval( $_GET['paged'] ) ) : 1;
 $offset    = ( $page - 1 ) * $per_page;
+$orderby   = isset( $_GET['orderby'] ) ? sanitize_text_field( $_GET['orderby'] ) : 'joined';
 
 // Build the WHERE clause for searching:
 $where_sql   = '';
@@ -37,14 +38,35 @@ if ( $search_term ) {
 // Fetch total count (for pagination)
 $total_members = $wpdb->get_var( "SELECT COUNT(*) FROM {$members_table} {$where_sql}" );
 
-// Fetch this page’s rows
-$members = $wpdb->get_results( $wpdb->prepare(
-    "SELECT * FROM {$members_table} {$where_sql} ORDER BY joined_at DESC LIMIT %d OFFSET %d",
-    $per_page,
-    $offset
-), ARRAY_A );
+// Fetch all rows so we can sort by metrics
+$members = $wpdb->get_results( "SELECT * FROM {$members_table} {$where_sql}", ARRAY_A );
 
-$total_pages = ceil( $total_members / $per_page );
+// Attach metrics for sorting
+foreach ( $members as &$m ) {
+    $summary                  = tta_get_member_history_summary( $m['id'] );
+    $m['__total_spent']       = $summary['total_spent'];
+    $m['__attended']          = $summary['attended'];
+    $m['__membership_length'] = time() - strtotime( $m['joined_at'] );
+}
+unset( $m );
+
+usort( $members, function ( $a, $b ) use ( $orderby ) {
+    switch ( $orderby ) {
+        case 'length':
+            return $b['__membership_length'] <=> $a['__membership_length'];
+        case 'attended':
+            return $b['__attended'] <=> $a['__attended'];
+        case 'spent':
+            return $b['__total_spent'] <=> $a['__total_spent'];
+        case 'joined':
+        default:
+            return strtotime( $b['joined_at'] ) - strtotime( $a['joined_at'] );
+    }
+} );
+
+$total_members = count( $members );
+$members       = array_slice( $members, $offset, $per_page );
+$total_pages   = ceil( $total_members / $per_page );
 
 ?>
 
@@ -68,7 +90,13 @@ $total_pages = ceil( $total_members / $per_page );
           value="<?php echo esc_attr( $_GET['s'] ?? '' ); ?>"
           placeholder="Search by first name, last name, or email…"
         >
-        <button class="button" type="submit">Search Members</button>
+        <select name="orderby" id="tta-member-orderby" onchange="this.form.submit()">
+          <option value="joined" <?php selected( $orderby, 'joined' ); ?>><?php esc_html_e( 'Newest Joined', 'tta' ); ?></option>
+          <option value="length" <?php selected( $orderby, 'length' ); ?>><?php esc_html_e( 'Membership Length', 'tta' ); ?></option>
+          <option value="attended" <?php selected( $orderby, 'attended' ); ?>><?php esc_html_e( 'Events Attended', 'tta' ); ?></option>
+          <option value="spent" <?php selected( $orderby, 'spent' ); ?>><?php esc_html_e( 'Total Spent', 'tta' ); ?></option>
+        </select>
+        <button class="button" type="submit"><?php esc_html_e( 'Search Members', 'tta' ); ?></button>
       </p>
     </form>
 

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/views/members-history.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/views/members-history.php
@@ -58,6 +58,10 @@ usort( $members, function ( $a, $b ) use ( $orderby ) {
             return $b['__attended'] <=> $a['__attended'];
         case 'spent':
             return $b['__total_spent'] <=> $a['__total_spent'];
+        case 'first':
+            return strcasecmp( $a['first_name'], $b['first_name'] );
+        case 'last':
+            return strcasecmp( $a['last_name'], $b['last_name'] );
         case 'joined':
         default:
             return strtotime( $b['joined_at'] ) - strtotime( $a['joined_at'] );
@@ -95,6 +99,8 @@ $total_pages   = ceil( $total_members / $per_page );
           <option value="length" <?php selected( $orderby, 'length' ); ?>><?php esc_html_e( 'Membership Length', 'tta' ); ?></option>
           <option value="attended" <?php selected( $orderby, 'attended' ); ?>><?php esc_html_e( 'Events Attended', 'tta' ); ?></option>
           <option value="spent" <?php selected( $orderby, 'spent' ); ?>><?php esc_html_e( 'Total Spent', 'tta' ); ?></option>
+          <option value="first" <?php selected( $orderby, 'first' ); ?>><?php esc_html_e( 'First Name', 'tta' ); ?></option>
+          <option value="last" <?php selected( $orderby, 'last' ); ?>><?php esc_html_e( 'Last Name', 'tta' ); ?></option>
         </select>
         <button class="button" type="submit"><?php esc_html_e( 'Search Members', 'tta' ); ?></button>
       </p>

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/views/members-manage.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/views/members-manage.php
@@ -20,6 +20,7 @@ $members_table = $wpdb->prefix . 'tta_members';
 $per_page = 10;
 $page      = isset( $_GET['paged'] ) ? max( 1, intval( $_GET['paged'] ) ) : 1;
 $offset    = ( $page - 1 ) * $per_page;
+$orderby   = isset( $_GET['orderby'] ) ? sanitize_text_field( $_GET['orderby'] ) : 'joined';
 
 // Build the WHERE clause for searching:
 $where_sql   = '';
@@ -37,14 +38,39 @@ if ( $search_term ) {
 // Fetch total count (for pagination)
 $total_members = $wpdb->get_var( "SELECT COUNT(*) FROM {$members_table} {$where_sql}" );
 
-// Fetch this page’s rows
-$members = $wpdb->get_results( $wpdb->prepare(
-    "SELECT * FROM {$members_table} {$where_sql} ORDER BY joined_at DESC LIMIT %d OFFSET %d",
-    $per_page,
-    $offset
-), ARRAY_A );
+// Fetch all rows so we can sort by metrics
+$members = $wpdb->get_results( "SELECT * FROM {$members_table} {$where_sql}", ARRAY_A );
 
-$total_pages = ceil( $total_members / $per_page );
+// Attach metrics for optional sorting
+foreach ( $members as &$m ) {
+    $summary                  = tta_get_member_history_summary( $m['id'] );
+    $m['__total_spent']       = $summary['total_spent'];
+    $m['__attended']          = $summary['attended'];
+    $m['__membership_length'] = time() - strtotime( $m['joined_at'] );
+}
+unset( $m );
+
+usort( $members, function ( $a, $b ) use ( $orderby ) {
+    switch ( $orderby ) {
+        case 'length':
+            return $b['__membership_length'] <=> $a['__membership_length'];
+        case 'attended':
+            return $b['__attended'] <=> $a['__attended'];
+        case 'spent':
+            return $b['__total_spent'] <=> $a['__total_spent'];
+        case 'first':
+            return strcasecmp( $a['first_name'], $b['first_name'] );
+        case 'last':
+            return strcasecmp( $a['last_name'], $b['last_name'] );
+        case 'joined':
+        default:
+            return strtotime( $b['joined_at'] ) - strtotime( $a['joined_at'] );
+    }
+} );
+
+$total_members = count( $members );
+$members       = array_slice( $members, $offset, $per_page );
+$total_pages   = ceil( $total_members / $per_page );
 
 ?>
 
@@ -68,6 +94,14 @@ $total_pages = ceil( $total_members / $per_page );
           value="<?php echo esc_attr( $_GET['s'] ?? '' ); ?>"
           placeholder="Search by first name, last name, or email…"
         >
+        <select name="orderby" id="tta-member-orderby" onchange="this.form.submit()">
+          <option value="joined" <?php selected( $orderby, 'joined' ); ?>><?php esc_html_e( 'Newest Joined', 'tta' ); ?></option>
+          <option value="length" <?php selected( $orderby, 'length' ); ?>><?php esc_html_e( 'Membership Length', 'tta' ); ?></option>
+          <option value="attended" <?php selected( $orderby, 'attended' ); ?>><?php esc_html_e( 'Events Attended', 'tta' ); ?></option>
+          <option value="spent" <?php selected( $orderby, 'spent' ); ?>><?php esc_html_e( 'Total Spent', 'tta' ); ?></option>
+          <option value="first" <?php selected( $orderby, 'first' ); ?>><?php esc_html_e( 'First Name', 'tta' ); ?></option>
+          <option value="last" <?php selected( $orderby, 'last' ); ?>><?php esc_html_e( 'Last Name', 'tta' ); ?></option>
+        </select>
         <button class="button" type="submit">Search Members</button>
       </p>
     </form>

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/views/members-manage.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/views/members-manage.php
@@ -20,7 +20,8 @@ $members_table = $wpdb->prefix . 'tta_members';
 $per_page = 10;
 $page      = isset( $_GET['paged'] ) ? max( 1, intval( $_GET['paged'] ) ) : 1;
 $offset    = ( $page - 1 ) * $per_page;
-$orderby   = isset( $_GET['orderby'] ) ? sanitize_text_field( $_GET['orderby'] ) : 'joined';
+$orderby_param = isset( $_GET['orderby'] ) ? sanitize_text_field( $_GET['orderby'] ) : '';
+$orderby       = $orderby_param ? $orderby_param : 'joined';
 
 // Build the WHERE clause for searching:
 $where_sql   = '';
@@ -94,15 +95,17 @@ $total_pages   = ceil( $total_members / $per_page );
           value="<?php echo esc_attr( $_GET['s'] ?? '' ); ?>"
           placeholder="Search by first name, last name, or email…"
         >
-        <select name="orderby" id="tta-member-orderby" onchange="this.form.submit()">
-          <option value="joined" <?php selected( $orderby, 'joined' ); ?>><?php esc_html_e( 'Newest Joined', 'tta' ); ?></option>
-          <option value="length" <?php selected( $orderby, 'length' ); ?>><?php esc_html_e( 'Membership Length', 'tta' ); ?></option>
-          <option value="attended" <?php selected( $orderby, 'attended' ); ?>><?php esc_html_e( 'Events Attended', 'tta' ); ?></option>
-          <option value="spent" <?php selected( $orderby, 'spent' ); ?>><?php esc_html_e( 'Total Spent', 'tta' ); ?></option>
-          <option value="first" <?php selected( $orderby, 'first' ); ?>><?php esc_html_e( 'First Name', 'tta' ); ?></option>
-          <option value="last" <?php selected( $orderby, 'last' ); ?>><?php esc_html_e( 'Last Name', 'tta' ); ?></option>
-        </select>
         <button class="button" type="submit">Search Members</button>
+        <select name="orderby" id="tta-member-orderby" onchange="this.form.submit()">
+          <option value="" disabled <?php selected( $orderby_param, '' ); ?>><?php esc_html_e( 'Sort By…', 'tta' ); ?></option>
+          <option value="joined" <?php selected( $orderby_param, 'joined' ); ?>><?php esc_html_e( 'Newest Joined', 'tta' ); ?></option>
+          <option value="length" <?php selected( $orderby_param, 'length' ); ?>><?php esc_html_e( 'Membership Length', 'tta' ); ?></option>
+          <option value="attended" <?php selected( $orderby_param, 'attended' ); ?>><?php esc_html_e( 'Events Attended', 'tta' ); ?></option>
+          <option value="spent" <?php selected( $orderby_param, 'spent' ); ?>><?php esc_html_e( 'Total Spent', 'tta' ); ?></option>
+          <option value="first" <?php selected( $orderby_param, 'first' ); ?>><?php esc_html_e( 'First Name', 'tta' ); ?></option>
+          <option value="last" <?php selected( $orderby_param, 'last' ); ?>><?php esc_html_e( 'Last Name', 'tta' ); ?></option>
+        </select>
+        <a href="<?php echo esc_url( admin_url( 'admin.php?page=tta-members&tab=manage' ) ); ?>" class="button"><?php esc_html_e( 'Clear Sorting', 'tta' ); ?></a>
       </p>
     </form>
 
@@ -177,14 +180,18 @@ $total_pages   = ceil( $total_members / $per_page );
         <div class="tablenav">
             <div class="tablenav-pages">
                 <?php
-                    echo paginate_links( [
+                    $pagination_args = [
                         'base'      => add_query_arg( 'paged', '%#%' ),
                         'format'    => '',
                         'prev_text' => '&laquo;',
                         'next_text' => '&raquo;',
                         'total'     => $total_pages,
                         'current'   => $page,
-                    ] );
+                        'end_size'  => 1,
+                        'mid_size'  => $page === 1 ? 19 : 2,
+                    ];
+
+                    echo paginate_links( $pagination_args );
                 ?>
             </div>
         </div>

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/api/class-authorizenet-api.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/api/class-authorizenet-api.php
@@ -13,15 +13,15 @@ class TTA_AuthorizeNet_API {
     protected $environment;
 
     /**
-     * Log raw API responses to the PHP error log and debug log.
+     * Log raw API responses to the internal debug log.
      *
-     * @param string $context Context label describing the request.
+     * @param string $context  Context label describing the request.
      * @param mixed  $response Response object returned by the SDK.
      * @return void
      */
     protected function log_response( $context, $response ) {
         $msg = $context . ': ' . print_r( $response, true );
-        error_log( '[TTA] ' . $msg );
+        TTA_Debug_Logger::log( $msg );
     }
 
     /**

--- a/docs/AdminListSorting.md
+++ b/docs/AdminListSorting.md
@@ -1,9 +1,9 @@
 # Admin List Sorting Options
 
-Several admin pages now include dropdowns to change the order of list tables:
+Several admin pages include dropdowns to change the order of list tables. The dropdowns now start with a disabled **Sort By…** option so it’s clear no custom order is active until one is selected. A **Clear Sorting** button beside each dropdown reloads the page without any sorting or pagination parameters.
 
 - **Member History** and **Manage Members** can sort by membership length, total amount spent, events attended, first name, last name or join date.
 - **Manage Events** can sort upcoming events first (default) or by date ascending/descending or alphabetically by name.
 - **Archived Events** can sort newest or oldest first or alphabetically by name.
 
-Use the dropdown above each table to select an order and results will refresh automatically.
+Use the dropdown above each table to select an order and results will refresh automatically. Clicking **Clear Sorting** returns you to the default view. When viewing the first page of results, up to the first twenty pages are now shown in the pagination links for easier navigation.

--- a/docs/AdminListSorting.md
+++ b/docs/AdminListSorting.md
@@ -1,0 +1,9 @@
+# Admin List Sorting Options
+
+Several admin pages now include dropdowns to change the order of list tables:
+
+- **Member History** and **Manage Members** can sort by membership length, total amount spent, events attended, first name, last name or join date.
+- **Manage Events** can sort upcoming events first (default) or by date ascending/descending or alphabetically by name.
+- **Archived Events** can sort newest or oldest first or alphabetically by name.
+
+Use the dropdown above each table to select an order and results will refresh automatically.

--- a/docs/MemberHistoryAdmin.md
+++ b/docs/MemberHistoryAdmin.md
@@ -2,7 +2,7 @@
 
 The **Member History** tab is available under **Members** in the WordPress admin. It lists all members just like the Manage Members tab. Clicking a member row loads a detailed history view showing:
 
-Members can now be sorted by the length of their membership, the number of events they've attended or the total amount they've spent. Use the dropdown above the table to choose a sort order.
+Members can now be sorted by membership length, events attended, total amount spent or alphabetically by first or last name. Use the dropdown above the table to choose a sort order.
 
 - Total amount spent across all transactions, including membership purchases and recurring charges
 - Count of events they have purchased

--- a/docs/MemberHistoryAdmin.md
+++ b/docs/MemberHistoryAdmin.md
@@ -2,7 +2,7 @@
 
 The **Member History** tab is available under **Members** in the WordPress admin. It lists all members just like the Manage Members tab. Clicking a member row loads a detailed history view showing:
 
-Members can now be sorted by membership length, events attended, total amount spent or alphabetically by first or last name. Use the dropdown above the table to choose a sort order.
+Members can now be sorted by membership length, events attended, total amount spent or alphabetically by first or last name. The dropdown begins with a disabled **Sort By…** option so the default order is obvious. A **Clear Sorting** button resets the view back to this default.
 
 - Total amount spent across all transactions, including membership purchases and recurring charges
 - Count of events they have purchased

--- a/docs/MemberHistoryAdmin.md
+++ b/docs/MemberHistoryAdmin.md
@@ -2,6 +2,8 @@
 
 The **Member History** tab is available under **Members** in the WordPress admin. It lists all members just like the Manage Members tab. Clicking a member row loads a detailed history view showing:
 
+Members can now be sorted by the length of their membership, the number of events they've attended or the total amount they've spent. Use the dropdown above the table to choose a sort order.
+
 - Total amount spent across all transactions, including membership purchases and recurring charges
 - Count of events they have purchased
 - Count of events checked in


### PR DESCRIPTION
## Summary
- allow selecting sort order on Member History list
- compute metrics for each member to sort by membership length, events attended, or total spend
- document the new sort dropdown in MemberHistoryAdmin.md

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6877a57f188083208523b0e33dbc0baf