### PR TITLE
Add event metrics export to admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ If these constants are not defined, checkout will fail and an admin notice will 
 - [Membership Benefits](docs/MembershipBenefits.md)
 - [Member Dashboard](docs/MemberDashboard.md)
 - [Member History Admin](docs/MemberHistoryAdmin.md)
+- [Admin List Sorting Options](docs/AdminListSorting.md)
+- [Event Metrics Export](docs/EventMetricsExport.md)
 - [TTA Refund Requests Admin](docs/RefundRequestsAdmin.md)
 - [TTA Ads Admin](docs/AdsAdmin.md)
 - [Event Check-In Page](docs/EventCheckInAdmin.md)

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/views/events-archive.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/views/events-archive.php
@@ -3,6 +3,13 @@
 ?><?php
 global $wpdb;
 $table = $wpdb->prefix . 'tta_events_archive';
+// Handle export
+if ( isset( $_POST['tta_export_events'] ) && check_admin_referer( 'tta_export_events_nonce' ) ) {
+    $start = isset( $_POST['start_date'] ) ? sanitize_text_field( $_POST['start_date'] ) : '';
+    $end   = isset( $_POST['end_date'] ) ? sanitize_text_field( $_POST['end_date'] ) : '';
+    tta_export_event_metrics_report( $start, $end );
+}
+
 
 // Handle deletion
 if ( isset( $_GET['action'] ) && $_GET['action'] === 'delete' && isset( $_GET['event_id'] ) ) {
@@ -58,22 +65,29 @@ if ( $search ) {
 $per_page = 20;
 $paged    = isset( $_GET['paged'] ) ? max( 1, intval( $_GET['paged'] ) ) : 1;
 $offset   = ( $paged - 1 ) * $per_page;
+$orderby_param = isset( $_GET['orderby'] ) ? sanitize_text_field( $_GET['orderby'] ) : '';
+$orderby       = $orderby_param ? $orderby_param : 'date_desc';
 
 // Total count
 $total = $wpdb->get_var( "SELECT COUNT(*) FROM {$table} {$where}" );
 
 // Fetch events in desired order
-$sql = "
-    SELECT *
-      FROM {$table}
-      {$where}
- ORDER
-    BY
-      CASE WHEN `date` >= CURDATE() THEN 0 ELSE 1 END ASC,
-      CASE WHEN `date` >= CURDATE() THEN `date` ELSE NULL END ASC,
-      CASE WHEN `date` <  CURDATE() THEN `date` ELSE NULL END DESC
-    LIMIT %d, %d
-";
+switch ( $orderby ) {
+    case 'date_asc':
+        $order_sql = 'ORDER BY `date` ASC';
+        break;
+    case 'date_desc':
+        $order_sql = 'ORDER BY `date` DESC';
+        break;
+    case 'name':
+        $order_sql = 'ORDER BY name ASC';
+        break;
+    default:
+        $order_sql = 'ORDER BY `date` DESC';
+        break;
+}
+
+$sql = "SELECT * FROM {$table} {$where} {$order_sql} LIMIT %d, %d";
 $events = $wpdb->get_results(
     $wpdb->prepare( $sql, $offset, $per_page ),
     ARRAY_A
@@ -87,7 +101,27 @@ $events = $wpdb->get_results(
         <label for="event-search-input" class="screen-reader-text">Search Events:</label>
         <input type="search" id="event-search-input" name="s" value="<?php echo esc_attr( $search ); ?>">
         <button class="button" type="submit">Search Events</button>
+        <select name="orderby" onchange="this.form.submit()">
+            <option value="" disabled <?php selected( $orderby_param, '' ); ?>><?php esc_html_e( 'Sort By…', 'tta' ); ?></option>
+            <option value="date_desc" <?php selected( $orderby_param, 'date_desc' ); ?>><?php esc_html_e( 'Newest First', 'tta' ); ?></option>
+            <option value="date_asc" <?php selected( $orderby_param, 'date_asc' ); ?>><?php esc_html_e( 'Oldest First', 'tta' ); ?></option>
+            <option value="name" <?php selected( $orderby_param, 'name' ); ?>><?php esc_html_e( 'Event Name', 'tta' ); ?></option>
+        </select>
+        <a href="<?php echo esc_url( admin_url( 'admin.php?page=tta-events&tab=archive' ) ); ?>" class="button"><?php esc_html_e( 'Clear Sorting', 'tta' ); ?></a>
     </p>
+</form>
+
+<form method="post" style="margin-bottom:1em;">
+    <?php wp_nonce_field( 'tta_export_events_nonce' ); ?>
+    <input type="hidden" name="page" value="tta-events">
+    <input type="hidden" name="tab" value="archive">
+    <label><?php esc_html_e( 'Start Date', 'tta' ); ?>
+        <input type="date" name="start_date">
+    </label>
+    <label><?php esc_html_e( 'End Date', 'tta' ); ?>
+        <input type="date" name="end_date">
+    </label>
+    <button class="button" type="submit" name="tta_export_events" value="1"><?php esc_html_e( 'Export Metrics', 'tta' ); ?></button>
 </form>
 
 <table class="widefat striped">
@@ -179,6 +213,8 @@ echo paginate_links( [
     'total'     => ceil( $total / $per_page ),
     'prev_text' => '&laquo;',
     'next_text' => '&raquo;',
+    'end_size'  => 1,
+    'mid_size'  => $paged === 1 ? 19 : 2,
 ] );
 echo '</div></div>';
 ?>

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/views/events-manage.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/views/events-manage.php
@@ -3,6 +3,13 @@
 ?><?php
 global $wpdb;
 $table = $wpdb->prefix . 'tta_events';
+// Handle export
+if ( isset( $_POST['tta_export_events'] ) && check_admin_referer( 'tta_export_events_nonce' ) ) {
+    $start = isset( $_POST['start_date'] ) ? sanitize_text_field( $_POST['start_date'] ) : '';
+    $end   = isset( $_POST['end_date'] ) ? sanitize_text_field( $_POST['end_date'] ) : '';
+    tta_export_event_metrics_report( $start, $end );
+}
+
 
 // Handle deletion
 if ( isset( $_GET['action'] ) && $_GET['action'] === 'delete' && isset( $_GET['event_id'] ) ) {
@@ -85,22 +92,34 @@ if ( $search ) {
 $per_page = 20;
 $paged    = isset( $_GET['paged'] ) ? max( 1, intval( $_GET['paged'] ) ) : 1;
 $offset   = ( $paged - 1 ) * $per_page;
+$orderby_param = isset( $_GET['orderby'] ) ? sanitize_text_field( $_GET['orderby'] ) : '';
+$orderby       = $orderby_param ? $orderby_param : 'upcoming';
 
 // Total count
 $total = $wpdb->get_var( "SELECT COUNT(*) FROM {$table} {$where}" );
 
 // Fetch events in desired order
-$sql = "
-    SELECT *
-      FROM {$table}
-      {$where}
- ORDER
+switch ( $orderby ) {
+    case 'date_asc':
+        $order_sql = 'ORDER BY `date` ASC';
+        break;
+    case 'date_desc':
+        $order_sql = 'ORDER BY `date` DESC';
+        break;
+    case 'name':
+        $order_sql = 'ORDER BY name ASC';
+        break;
+    case 'upcoming':
+    default:
+        $order_sql = 'ORDER
     BY
       CASE WHEN `date` >= CURDATE() THEN 0 ELSE 1 END ASC,
       CASE WHEN `date` >= CURDATE() THEN `date` ELSE NULL END ASC,
-      CASE WHEN `date` <  CURDATE() THEN `date` ELSE NULL END DESC
-    LIMIT %d, %d
-";
+      CASE WHEN `date` <  CURDATE() THEN `date` ELSE NULL END DESC';
+        break;
+}
+
+$sql = "SELECT * FROM {$table} {$where} {$order_sql} LIMIT %d, %d";
 $events = $wpdb->get_results(
     $wpdb->prepare( $sql, $offset, $per_page ),
     ARRAY_A
@@ -114,7 +133,28 @@ $events = $wpdb->get_results(
         <label for="event-search-input" class="screen-reader-text">Search Events:</label>
         <input type="search" id="event-search-input" name="s" value="<?php echo esc_attr( $search ); ?>">
         <button class="button" type="submit">Search Events</button>
+        <select name="orderby" onchange="this.form.submit()">
+            <option value="" disabled <?php selected( $orderby_param, '' ); ?>><?php esc_html_e( 'Sort By…', 'tta' ); ?></option>
+            <option value="upcoming" <?php selected( $orderby_param, 'upcoming' ); ?>><?php esc_html_e( 'Upcoming First', 'tta' ); ?></option>
+            <option value="date_asc" <?php selected( $orderby_param, 'date_asc' ); ?>><?php esc_html_e( 'Date Ascending', 'tta' ); ?></option>
+            <option value="date_desc" <?php selected( $orderby_param, 'date_desc' ); ?>><?php esc_html_e( 'Date Descending', 'tta' ); ?></option>
+            <option value="name" <?php selected( $orderby_param, 'name' ); ?>><?php esc_html_e( 'Event Name', 'tta' ); ?></option>
+        </select>
+        <a href="<?php echo esc_url( admin_url( 'admin.php?page=tta-events&tab=manage' ) ); ?>" class="button"><?php esc_html_e( 'Clear Sorting', 'tta' ); ?></a>
     </p>
+</form>
+
+<form method="post" style="margin-bottom:1em;">
+    <?php wp_nonce_field( 'tta_export_events_nonce' ); ?>
+    <input type="hidden" name="page" value="tta-events">
+    <input type="hidden" name="tab" value="manage">
+    <label><?php esc_html_e( 'Start Date', 'tta' ); ?>
+        <input type="date" name="start_date">
+    </label>
+    <label><?php esc_html_e( 'End Date', 'tta' ); ?>
+        <input type="date" name="end_date">
+    </label>
+    <button class="button" type="submit" name="tta_export_events" value="1"><?php esc_html_e( 'Export Metrics', 'tta' ); ?></button>
 </form>
 
 <table class="widefat striped">
@@ -221,6 +261,8 @@ echo paginate_links( [
     'total'     => ceil( $total / $per_page ),
     'prev_text' => '&laquo;',
     'next_text' => '&raquo;',
+    'end_size'  => 1,
+    'mid_size'  => $paged === 1 ? 19 : 2,
 ] );
 echo '</div></div>';
 ?>

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/views/members-history.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/views/members-history.php
@@ -20,6 +20,8 @@ $members_table = $wpdb->prefix . 'tta_members';
 $per_page = 10;
 $page      = isset( $_GET['paged'] ) ? max( 1, intval( $_GET['paged'] ) ) : 1;
 $offset    = ( $page - 1 ) * $per_page;
+$orderby_param = isset( $_GET['orderby'] ) ? sanitize_text_field( $_GET['orderby'] ) : '';
+$orderby       = $orderby_param ? $orderby_param : 'joined';
 
 // Build the WHERE clause for searching:
 $where_sql   = '';
@@ -37,14 +39,39 @@ if ( $search_term ) {
 // Fetch total count (for pagination)
 $total_members = $wpdb->get_var( "SELECT COUNT(*) FROM {$members_table} {$where_sql}" );
 
-// Fetch this page’s rows
-$members = $wpdb->get_results( $wpdb->prepare(
-    "SELECT * FROM {$members_table} {$where_sql} ORDER BY joined_at DESC LIMIT %d OFFSET %d",
-    $per_page,
-    $offset
-), ARRAY_A );
+// Fetch all rows so we can sort by metrics
+$members = $wpdb->get_results( "SELECT * FROM {$members_table} {$where_sql}", ARRAY_A );
 
-$total_pages = ceil( $total_members / $per_page );
+// Attach metrics for sorting
+foreach ( $members as &$m ) {
+    $summary                  = tta_get_member_history_summary( $m['id'] );
+    $m['__total_spent']       = $summary['total_spent'];
+    $m['__attended']          = $summary['attended'];
+    $m['__membership_length'] = time() - strtotime( $m['joined_at'] );
+}
+unset( $m );
+
+usort( $members, function ( $a, $b ) use ( $orderby ) {
+    switch ( $orderby ) {
+        case 'length':
+            return $b['__membership_length'] <=> $a['__membership_length'];
+        case 'attended':
+            return $b['__attended'] <=> $a['__attended'];
+        case 'spent':
+            return $b['__total_spent'] <=> $a['__total_spent'];
+        case 'first':
+            return strcasecmp( $a['first_name'], $b['first_name'] );
+        case 'last':
+            return strcasecmp( $a['last_name'], $b['last_name'] );
+        case 'joined':
+        default:
+            return strtotime( $b['joined_at'] ) - strtotime( $a['joined_at'] );
+    }
+} );
+
+$total_members = count( $members );
+$members       = array_slice( $members, $offset, $per_page );
+$total_pages   = ceil( $total_members / $per_page );
 
 ?>
 
@@ -68,7 +95,17 @@ $total_pages = ceil( $total_members / $per_page );
           value="<?php echo esc_attr( $_GET['s'] ?? '' ); ?>"
           placeholder="Search by first name, last name, or email…"
         >
-        <button class="button" type="submit">Search Members</button>
+        <button class="button" type="submit"><?php esc_html_e( 'Search Members', 'tta' ); ?></button>
+        <select name="orderby" id="tta-member-orderby" onchange="this.form.submit()">
+          <option value="" disabled <?php selected( $orderby_param, '' ); ?>><?php esc_html_e( 'Sort By…', 'tta' ); ?></option>
+          <option value="joined" <?php selected( $orderby_param, 'joined' ); ?>><?php esc_html_e( 'Newest Joined', 'tta' ); ?></option>
+          <option value="length" <?php selected( $orderby_param, 'length' ); ?>><?php esc_html_e( 'Membership Length', 'tta' ); ?></option>
+          <option value="attended" <?php selected( $orderby_param, 'attended' ); ?>><?php esc_html_e( 'Events Attended', 'tta' ); ?></option>
+          <option value="spent" <?php selected( $orderby_param, 'spent' ); ?>><?php esc_html_e( 'Total Spent', 'tta' ); ?></option>
+          <option value="first" <?php selected( $orderby_param, 'first' ); ?>><?php esc_html_e( 'First Name', 'tta' ); ?></option>
+          <option value="last" <?php selected( $orderby_param, 'last' ); ?>><?php esc_html_e( 'Last Name', 'tta' ); ?></option>
+        </select>
+        <a href="<?php echo esc_url( admin_url( 'admin.php?page=tta-members&tab=history' ) ); ?>" class="button"><?php esc_html_e( 'Clear Sorting', 'tta' ); ?></a>
       </p>
     </form>
 
@@ -144,14 +181,18 @@ $total_pages = ceil( $total_members / $per_page );
         <div class="tablenav">
             <div class="tablenav-pages">
                 <?php
-                    echo paginate_links( [
+                    $pagination_args = [
                         'base'      => add_query_arg( 'paged', '%#%' ),
                         'format'    => '',
                         'prev_text' => '&laquo;',
                         'next_text' => '&raquo;',
                         'total'     => $total_pages,
                         'current'   => $page,
-                    ] );
+                        'end_size'  => 1,
+                        'mid_size'  => $page === 1 ? 19 : 2,
+                    ];
+
+                    echo paginate_links( $pagination_args );
                 ?>
             </div>
         </div>

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/views/members-manage.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/views/members-manage.php
@@ -20,6 +20,8 @@ $members_table = $wpdb->prefix . 'tta_members';
 $per_page = 10;
 $page      = isset( $_GET['paged'] ) ? max( 1, intval( $_GET['paged'] ) ) : 1;
 $offset    = ( $page - 1 ) * $per_page;
+$orderby_param = isset( $_GET['orderby'] ) ? sanitize_text_field( $_GET['orderby'] ) : '';
+$orderby       = $orderby_param ? $orderby_param : 'joined';
 
 // Build the WHERE clause for searching:
 $where_sql   = '';
@@ -37,14 +39,39 @@ if ( $search_term ) {
 // Fetch total count (for pagination)
 $total_members = $wpdb->get_var( "SELECT COUNT(*) FROM {$members_table} {$where_sql}" );
 
-// Fetch this page’s rows
-$members = $wpdb->get_results( $wpdb->prepare(
-    "SELECT * FROM {$members_table} {$where_sql} ORDER BY joined_at DESC LIMIT %d OFFSET %d",
-    $per_page,
-    $offset
-), ARRAY_A );
+// Fetch all rows so we can sort by metrics
+$members = $wpdb->get_results( "SELECT * FROM {$members_table} {$where_sql}", ARRAY_A );
 
-$total_pages = ceil( $total_members / $per_page );
+// Attach metrics for optional sorting
+foreach ( $members as &$m ) {
+    $summary                  = tta_get_member_history_summary( $m['id'] );
+    $m['__total_spent']       = $summary['total_spent'];
+    $m['__attended']          = $summary['attended'];
+    $m['__membership_length'] = time() - strtotime( $m['joined_at'] );
+}
+unset( $m );
+
+usort( $members, function ( $a, $b ) use ( $orderby ) {
+    switch ( $orderby ) {
+        case 'length':
+            return $b['__membership_length'] <=> $a['__membership_length'];
+        case 'attended':
+            return $b['__attended'] <=> $a['__attended'];
+        case 'spent':
+            return $b['__total_spent'] <=> $a['__total_spent'];
+        case 'first':
+            return strcasecmp( $a['first_name'], $b['first_name'] );
+        case 'last':
+            return strcasecmp( $a['last_name'], $b['last_name'] );
+        case 'joined':
+        default:
+            return strtotime( $b['joined_at'] ) - strtotime( $a['joined_at'] );
+    }
+} );
+
+$total_members = count( $members );
+$members       = array_slice( $members, $offset, $per_page );
+$total_pages   = ceil( $total_members / $per_page );
 
 ?>
 
@@ -69,6 +96,16 @@ $total_pages = ceil( $total_members / $per_page );
           placeholder="Search by first name, last name, or email…"
         >
         <button class="button" type="submit">Search Members</button>
+        <select name="orderby" id="tta-member-orderby" onchange="this.form.submit()">
+          <option value="" disabled <?php selected( $orderby_param, '' ); ?>><?php esc_html_e( 'Sort By…', 'tta' ); ?></option>
+          <option value="joined" <?php selected( $orderby_param, 'joined' ); ?>><?php esc_html_e( 'Newest Joined', 'tta' ); ?></option>
+          <option value="length" <?php selected( $orderby_param, 'length' ); ?>><?php esc_html_e( 'Membership Length', 'tta' ); ?></option>
+          <option value="attended" <?php selected( $orderby_param, 'attended' ); ?>><?php esc_html_e( 'Events Attended', 'tta' ); ?></option>
+          <option value="spent" <?php selected( $orderby_param, 'spent' ); ?>><?php esc_html_e( 'Total Spent', 'tta' ); ?></option>
+          <option value="first" <?php selected( $orderby_param, 'first' ); ?>><?php esc_html_e( 'First Name', 'tta' ); ?></option>
+          <option value="last" <?php selected( $orderby_param, 'last' ); ?>><?php esc_html_e( 'Last Name', 'tta' ); ?></option>
+        </select>
+        <a href="<?php echo esc_url( admin_url( 'admin.php?page=tta-members&tab=manage' ) ); ?>" class="button"><?php esc_html_e( 'Clear Sorting', 'tta' ); ?></a>
       </p>
     </form>
 
@@ -143,14 +180,18 @@ $total_pages = ceil( $total_members / $per_page );
         <div class="tablenav">
             <div class="tablenav-pages">
                 <?php
-                    echo paginate_links( [
+                    $pagination_args = [
                         'base'      => add_query_arg( 'paged', '%#%' ),
                         'format'    => '',
                         'prev_text' => '&laquo;',
                         'next_text' => '&raquo;',
                         'total'     => $total_pages,
                         'current'   => $page,
-                    ] );
+                        'end_size'  => 1,
+                        'mid_size'  => $page === 1 ? 19 : 2,
+                    ];
+
+                    echo paginate_links( $pagination_args );
                 ?>
             </div>
         </div>

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/api/class-authorizenet-api.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/api/class-authorizenet-api.php
@@ -13,15 +13,15 @@ class TTA_AuthorizeNet_API {
     protected $environment;
 
     /**
-     * Log raw API responses to the PHP error log and debug log.
+     * Log raw API responses to the internal debug log.
      *
-     * @param string $context Context label describing the request.
+     * @param string $context  Context label describing the request.
      * @param mixed  $response Response object returned by the SDK.
      * @return void
      */
     protected function log_response( $context, $response ) {
         $msg = $context . ': ' . print_r( $response, true );
-        error_log( '[TTA] ' . $msg );
+        TTA_Debug_Logger::log( $msg );
     }
 
     /**

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
@@ -4576,3 +4576,162 @@ function tta_login_redirect( $redirect_to, $requested_redirect_to, $user ) {
 }
 add_filter( 'login_redirect', 'tta_login_redirect', 10, 3 );
 
+/**
+ * Get aggregated metrics for an event.
+ *
+ * @param string $event_ute_id Event ute_id.
+ * @return array{
+ *     expected_attendees:int,
+ *     checked_in:int,
+ *     no_show:int,
+ *     refund_requests:int,
+ *     refunded_amount:float,
+ *     revenue:float,
+ *     waitlist_count:int
+ * }
+ */
+function tta_get_event_metrics( $event_ute_id ) {
+    global $wpdb;
+
+    $event_ute_id = sanitize_text_field( $event_ute_id );
+    if ( '' === $event_ute_id ) {
+        return [
+            'expected_attendees' => 0,
+            'checked_in'        => 0,
+            'no_show'           => 0,
+            'refund_requests'   => 0,
+            'refunded_amount'   => 0,
+            'revenue'           => 0,
+            'waitlist_count'    => 0,
+        ];
+    }
+
+    $attendees = tta_get_event_attendees_with_status( $event_ute_id );
+    $metrics = [
+        'expected_attendees' => count( $attendees ),
+        'checked_in'        => 0,
+        'no_show'           => 0,
+        'refund_requests'   => 0,
+        'refunded_amount'   => 0,
+        'revenue'           => 0,
+        'waitlist_count'    => 0,
+    ];
+    foreach ( $attendees as $a ) {
+        if ( 'checked_in' === $a['status'] ) {
+            $metrics['checked_in']++;
+        } elseif ( 'no_show' === $a['status'] ) {
+            $metrics['no_show']++;
+        }
+    }
+
+    $event_id = (int) $wpdb->get_var(
+        $wpdb->prepare(
+            "SELECT id FROM {$wpdb->prefix}tta_events WHERE ute_id = %s UNION SELECT id FROM {$wpdb->prefix}tta_events_archive WHERE ute_id = %s LIMIT 1",
+            $event_ute_id,
+            $event_ute_id
+        )
+    );
+
+    if ( $event_id ) {
+        $ticket_rows = $wpdb->get_results(
+            $wpdb->prepare(
+                "SELECT id FROM {$wpdb->prefix}tta_tickets WHERE event_ute_id = %s UNION ALL SELECT id FROM {$wpdb->prefix}tta_tickets_archive WHERE event_ute_id = %s",
+                $event_ute_id,
+                $event_ute_id
+            ),
+            ARRAY_A
+        );
+        foreach ( $ticket_rows as $tr ) {
+            $tid = intval( $tr['id'] );
+            $metrics['refund_requests'] += count( tta_get_ticket_pending_refund_attendees( $tid, $event_id ) );
+            foreach ( tta_get_ticket_refunded_attendees( $tid, $event_id ) as $ref ) {
+                $metrics['refunded_amount'] += floatval( $ref['amount_paid'] );
+            }
+        }
+    }
+
+    // Revenue from transactions
+    $like = '%' . $wpdb->esc_like( $event_ute_id ) . '%';
+    $tx_rows = $wpdb->get_results(
+        $wpdb->prepare(
+            "SELECT details FROM {$wpdb->prefix}tta_transactions WHERE details LIKE %s",
+            $like
+        ),
+        ARRAY_A
+    );
+    foreach ( $tx_rows as $tx ) {
+        $items = json_decode( $tx['details'], true );
+        if ( ! is_array( $items ) ) {
+            continue;
+        }
+        foreach ( $items as $it ) {
+            if ( ( $it['event_ute_id'] ?? '' ) === $event_ute_id ) {
+                $qty   = intval( $it['quantity'] ?? 1 );
+                $price = floatval( $it['final_price'] ?? ( $it['price'] ?? 0 ) );
+                $metrics['revenue'] += $price * $qty;
+            }
+        }
+    }
+
+    $metrics['waitlist_count'] = (int) $wpdb->get_var(
+        $wpdb->prepare(
+            "SELECT COUNT(*) FROM {$wpdb->prefix}tta_waitlist WHERE event_ute_id = %s",
+            $event_ute_id
+        )
+    );
+
+    return $metrics;
+}
+
+/**
+ * Export event metrics to an Excel spreadsheet.
+ *
+ * @param string $start_date Optional start date Y-m-d.
+ * @param string $end_date   Optional end date Y-m-d.
+ */
+function tta_export_event_metrics_report( $start_date = '', $end_date = '' ) {
+    global $wpdb;
+
+    $events_table  = $wpdb->prefix . 'tta_events';
+    $archive_table = $wpdb->prefix . 'tta_events_archive';
+    $where  = '1=1';
+    $params = [];
+    if ( $start_date ) {
+        $where  .= ' AND date >= %s';
+        $params[] = $start_date;
+    }
+    if ( $end_date ) {
+        $where  .= ' AND date <= %s';
+        $params[] = $end_date;
+    }
+
+    $sql = "SELECT * FROM {$events_table} WHERE {$where} UNION ALL SELECT * FROM {$archive_table} WHERE {$where} ORDER BY date DESC";
+    $events = $wpdb->get_results( $wpdb->prepare( $sql, array_merge( $params, $params ) ), ARRAY_A );
+    if ( empty( $events ) ) {
+        wp_die( esc_html__( 'No events found for that range.', 'tta' ) );
+    }
+
+    $headers = array_keys( $events[0] );
+    $metric_headers = [ 'expected_attendees', 'checked_in', 'no_show', 'refund_requests', 'refunded_amount', 'revenue', 'waitlist_count' ];
+
+    $spreadsheet = new \PhpOffice\PhpSpreadsheet\Spreadsheet();
+    $sheet = $spreadsheet->getActiveSheet();
+    $sheet->fromArray( array_merge( $headers, $metric_headers ), null, 'A1' );
+
+    $row = 2;
+    foreach ( $events as $ev ) {
+        $metrics = tta_get_event_metrics( $ev['ute_id'] );
+        $sheet->fromArray( array_merge( array_values( $ev ), array_values( $metrics ) ), null, 'A' . $row );
+        $row++;
+    }
+
+    $writer   = new \PhpOffice\PhpSpreadsheet\Writer\Xlsx( $spreadsheet );
+    $tmp_file = wp_tempnam();
+    $writer->save( $tmp_file );
+
+    header( 'Content-Type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' );
+    header( 'Content-Disposition: attachment; filename="event-report.xlsx"' );
+    readfile( $tmp_file );
+    unlink( $tmp_file );
+    exit;
+}

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "require": {
-        "authorizenet/authorizenet": "^2"
+        "authorizenet/authorizenet": "^2",
+        "phpoffice/phpspreadsheet": "^4.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^10"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8b044f7da3730a1bef38afd70a13fb96",
+    "content-hash": "8181ca5954e74779f0b8bdddabb7dea5",
     "packages": [
         {
             "name": "authorizenet/authorizenet",
@@ -48,6 +48,587 @@
                 "source": "https://github.com/AuthorizeNet/sdk-php/tree/2.0.4"
             },
             "time": "2024-09-18T06:23:52+00:00"
+        },
+        {
+            "name": "composer/pcre",
+            "version": "3.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/pcre.git",
+                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan": "<1.11.10"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.12 || ^2",
+                "phpstan/phpstan-strict-rules": "^1 || ^2",
+                "phpunit/phpunit": "^8 || ^9"
+            },
+            "type": "library",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Pcre\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "PCRE wrapping library that offers type-safe preg_* replacements.",
+            "keywords": [
+                "PCRE",
+                "preg",
+                "regex",
+                "regular expression"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/pcre/issues",
+                "source": "https://github.com/composer/pcre/tree/3.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-12T16:29:46+00:00"
+        },
+        {
+            "name": "maennchen/zipstream-php",
+            "version": "3.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/maennchen/ZipStream-PHP.git",
+                "reference": "aeadcf5c412332eb426c0f9b4485f6accba2a99f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/maennchen/ZipStream-PHP/zipball/aeadcf5c412332eb426c0f9b4485f6accba2a99f",
+                "reference": "aeadcf5c412332eb426c0f9b4485f6accba2a99f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "ext-zlib": "*",
+                "php-64bit": "^8.2"
+            },
+            "require-dev": {
+                "brianium/paratest": "^7.7",
+                "ext-zip": "*",
+                "friendsofphp/php-cs-fixer": "^3.16",
+                "guzzlehttp/guzzle": "^7.5",
+                "mikey179/vfsstream": "^1.6",
+                "php-coveralls/php-coveralls": "^2.5",
+                "phpunit/phpunit": "^11.0",
+                "vimeo/psalm": "^6.0"
+            },
+            "suggest": {
+                "guzzlehttp/psr7": "^2.4",
+                "psr/http-message": "^2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ZipStream\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paul Duncan",
+                    "email": "pabs@pablotron.org"
+                },
+                {
+                    "name": "Jonatan Männchen",
+                    "email": "jonatan@maennchen.ch"
+                },
+                {
+                    "name": "Jesse Donat",
+                    "email": "donatj@gmail.com"
+                },
+                {
+                    "name": "András Kolesár",
+                    "email": "kolesar@kolesar.hu"
+                }
+            ],
+            "description": "ZipStream is a library for dynamically streaming dynamic zip files from PHP without writing to the disk at all on the server.",
+            "keywords": [
+                "stream",
+                "zip"
+            ],
+            "support": {
+                "issues": "https://github.com/maennchen/ZipStream-PHP/issues",
+                "source": "https://github.com/maennchen/ZipStream-PHP/tree/3.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/maennchen",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-01-27T12:07:53+00:00"
+        },
+        {
+            "name": "markbaker/complex",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/MarkBaker/PHPComplex.git",
+                "reference": "95c56caa1cf5c766ad6d65b6344b807c1e8405b9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MarkBaker/PHPComplex/zipball/95c56caa1cf5c766ad6d65b6344b807c1e8405b9",
+                "reference": "95c56caa1cf5c766ad6d65b6344b807c1e8405b9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "dev-master",
+                "phpcompatibility/php-compatibility": "^9.3",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",
+                "squizlabs/php_codesniffer": "^3.7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Complex\\": "classes/src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mark Baker",
+                    "email": "mark@lange.demon.co.uk"
+                }
+            ],
+            "description": "PHP Class for working with complex numbers",
+            "homepage": "https://github.com/MarkBaker/PHPComplex",
+            "keywords": [
+                "complex",
+                "mathematics"
+            ],
+            "support": {
+                "issues": "https://github.com/MarkBaker/PHPComplex/issues",
+                "source": "https://github.com/MarkBaker/PHPComplex/tree/3.0.2"
+            },
+            "time": "2022-12-06T16:21:08+00:00"
+        },
+        {
+            "name": "markbaker/matrix",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/MarkBaker/PHPMatrix.git",
+                "reference": "728434227fe21be27ff6d86621a1b13107a2562c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MarkBaker/PHPMatrix/zipball/728434227fe21be27ff6d86621a1b13107a2562c",
+                "reference": "728434227fe21be27ff6d86621a1b13107a2562c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "dev-master",
+                "phpcompatibility/php-compatibility": "^9.3",
+                "phpdocumentor/phpdocumentor": "2.*",
+                "phploc/phploc": "^4.0",
+                "phpmd/phpmd": "2.*",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",
+                "sebastian/phpcpd": "^4.0",
+                "squizlabs/php_codesniffer": "^3.7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Matrix\\": "classes/src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mark Baker",
+                    "email": "mark@demon-angel.eu"
+                }
+            ],
+            "description": "PHP Class for working with matrices",
+            "homepage": "https://github.com/MarkBaker/PHPMatrix",
+            "keywords": [
+                "mathematics",
+                "matrix",
+                "vector"
+            ],
+            "support": {
+                "issues": "https://github.com/MarkBaker/PHPMatrix/issues",
+                "source": "https://github.com/MarkBaker/PHPMatrix/tree/3.0.1"
+            },
+            "time": "2022-12-02T22:17:43+00:00"
+        },
+        {
+            "name": "phpoffice/phpspreadsheet",
+            "version": "4.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPOffice/PhpSpreadsheet.git",
+                "reference": "747ccd1b443e85e0cfc0d52acf50e4d15ef959eb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/747ccd1b443e85e0cfc0d52acf50e4d15ef959eb",
+                "reference": "747ccd1b443e85e0cfc0d52acf50e4d15ef959eb",
+                "shasum": ""
+            },
+            "require": {
+                "composer/pcre": "^1||^2||^3",
+                "ext-ctype": "*",
+                "ext-dom": "*",
+                "ext-fileinfo": "*",
+                "ext-gd": "*",
+                "ext-iconv": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-simplexml": "*",
+                "ext-xml": "*",
+                "ext-xmlreader": "*",
+                "ext-xmlwriter": "*",
+                "ext-zip": "*",
+                "ext-zlib": "*",
+                "maennchen/zipstream-php": "^2.1 || ^3.0",
+                "markbaker/complex": "^3.0",
+                "markbaker/matrix": "^3.0",
+                "php": "^8.1",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.0",
+                "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "dev-main",
+                "dompdf/dompdf": "^2.0 || ^3.0",
+                "friendsofphp/php-cs-fixer": "^3.2",
+                "mitoteam/jpgraph": "^10.3",
+                "mpdf/mpdf": "^8.1.1",
+                "phpcompatibility/php-compatibility": "^9.3",
+                "phpstan/phpstan": "^1.1 || ^2.0",
+                "phpstan/phpstan-deprecation-rules": "^1.0 || ^2.0",
+                "phpstan/phpstan-phpunit": "^1.0 || ^2.0",
+                "phpunit/phpunit": "^10.5",
+                "squizlabs/php_codesniffer": "^3.7",
+                "tecnickcom/tcpdf": "^6.5"
+            },
+            "suggest": {
+                "dompdf/dompdf": "Option for rendering PDF with PDF Writer",
+                "ext-intl": "PHP Internationalization Functions",
+                "mitoteam/jpgraph": "Option for rendering charts, or including charts with PDF or HTML Writers",
+                "mpdf/mpdf": "Option for rendering PDF with PDF Writer",
+                "tecnickcom/tcpdf": "Option for rendering PDF with PDF Writer"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PhpOffice\\PhpSpreadsheet\\": "src/PhpSpreadsheet"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Maarten Balliauw",
+                    "homepage": "https://blog.maartenballiauw.be"
+                },
+                {
+                    "name": "Mark Baker",
+                    "homepage": "https://markbakeruk.net"
+                },
+                {
+                    "name": "Franck Lefevre",
+                    "homepage": "https://rootslabs.net"
+                },
+                {
+                    "name": "Erik Tilt"
+                },
+                {
+                    "name": "Adrien Crivelli"
+                }
+            ],
+            "description": "PHPSpreadsheet - Read, Create and Write Spreadsheet documents in PHP - Spreadsheet engine",
+            "homepage": "https://github.com/PHPOffice/PhpSpreadsheet",
+            "keywords": [
+                "OpenXML",
+                "excel",
+                "gnumeric",
+                "ods",
+                "php",
+                "spreadsheet",
+                "xls",
+                "xlsx"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPOffice/PhpSpreadsheet/issues",
+                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/4.4.0"
+            },
+            "time": "2025-06-23T01:23:23+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-client"
+            },
+            "time": "2023-09-23T14:17:50+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory"
+            },
+            "time": "2024-04-15T12:06:14+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/2.0"
+            },
+            "time": "2023-04-04T09:54:51+00:00"
+        },
+        {
+            "name": "psr/simple-cache",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/simple-cache.git",
+                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/764e0b3939f5ca87cb904f570ef9be2d78a07865",
+                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\SimpleCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for simple caching",
+            "keywords": [
+                "cache",
+                "caching",
+                "psr",
+                "psr-16",
+                "simple-cache"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/simple-cache/tree/3.0.0"
+            },
+            "time": "2021-10-29T13:26:27+00:00"
         }
     ],
     "packages-dev": [

--- a/docs/AdminListSorting.md
+++ b/docs/AdminListSorting.md
@@ -1,0 +1,9 @@
+# Admin List Sorting Options
+
+Several admin pages include dropdowns to change the order of list tables. The dropdowns now start with a disabled **Sort By…** option so it’s clear no custom order is active until one is selected. A **Clear Sorting** button beside each dropdown reloads the page without any sorting or pagination parameters.
+
+- **Member History** and **Manage Members** can sort by membership length, total amount spent, events attended, first name, last name or join date.
+- **Manage Events** can sort upcoming events first (default) or by date ascending/descending or alphabetically by name.
+- **Archived Events** can sort newest or oldest first or alphabetically by name.
+
+Use the dropdown above each table to select an order and results will refresh automatically. Clicking **Clear Sorting** returns you to the default view. When viewing the first page of results, up to the first twenty pages are now shown in the pagination links for easier navigation.

--- a/docs/EventMetricsExport.md
+++ b/docs/EventMetricsExport.md
@@ -1,0 +1,15 @@
+# Event Metrics Export
+
+Administrators can export a spreadsheet of event metrics from either the **Manage Events** or **Archived Events** tabs. A short form above each table lets you optionally specify a start and end date. Leaving both fields blank exports all events.
+
+The spreadsheet includes every column from the events table along with additional metrics:
+
+- `expected_attendees` – number of purchased tickets (after refunds)
+- `checked_in` – count of attendees marked as checked in
+- `no_show` – count of attendees marked as no show
+- `refund_requests` – number of pending refund requests
+- `refunded_amount` – total amount refunded
+- `revenue` – gross revenue from ticket sales
+- `waitlist_count` – current waitlist entries
+
+Press **Export Metrics** and an `.xlsx` file downloads immediately.

--- a/docs/MemberHistoryAdmin.md
+++ b/docs/MemberHistoryAdmin.md
@@ -2,6 +2,8 @@
 
 The **Member History** tab is available under **Members** in the WordPress admin. It lists all members just like the Manage Members tab. Clicking a member row loads a detailed history view showing:
 
+Members can now be sorted by membership length, events attended, total amount spent or alphabetically by first or last name. The dropdown begins with a disabled **Sort By…** option so the default order is obvious. A **Clear Sorting** button resets the view back to this default.
+
 - Total amount spent across all transactions, including membership purchases and recurring charges
 - Count of events they have purchased
 - Count of events checked in


### PR DESCRIPTION
## Summary
- add phpspreadsheet dependency
- export event metrics from Manage and Archived Events
- document the new Event Metrics Export feature

## Testing
- `composer install`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6877a57f188083208523b0e33dbc0baf