### PR TITLE
Add dashicon to Discount Codes page

### DIFF
--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-discount-codes-admin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-discount-codes-admin.php
@@ -18,7 +18,10 @@ class TTA_Discount_Codes_Admin {
             'manage_options',
             'tta-discount-codes',
             [ $this, 'render_page' ],
-            'dashicons-ticket',
+            // Use the price tag icon so the menu item matches other dashboard entries.
+            // This icon visually communicates that the screen is for managing codes
+            // that apply discounts during checkout.
+            'dashicons-tag',
             14
         );
     }

--- a/docs/DiscountCodesAdmin.md
+++ b/docs/DiscountCodesAdmin.md
@@ -2,6 +2,8 @@
 
 The **TTA Discount Codes** screen lets administrators create global discount codes that apply to any cart. These one-off codes are independent of individual events and stack with event-specific discounts.
 
+The menu entry now uses the WordPress `dashicons-tag` icon to match other dashboard items.
+
 Each code has three fields:
 
 - **Discount Code** – the text users enter at checkout.


### PR DESCRIPTION
## Summary
- add a `dashicons-tag` icon for the Discount Codes admin page
- note the new icon in Discount Codes admin docs

## Testing
- `composer install`
- `composer install` inside plugin
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6879349223388320b2d8f7aedcd3193f