### PR TITLE
Add inline registration flow to event page

### DIFF
--- a/app/public/wp-content/plugins/tta-management-plugin/assets/js/frontend/event-page.js
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/js/frontend/event-page.js
@@ -112,3 +112,72 @@ jQuery(function($){
     }
   });
 });
+
+jQuery(function($){
+  $('#tta-login-message').on('click', '.tta-show-register', function(e){
+    e.preventDefault();
+    $('#tta-login-wrap').fadeOut(200, function(){
+      $('#tta-register-form').fadeIn(200);
+    });
+  });
+
+  $('#tta-register-form').on('submit', function(e){
+    e.preventDefault();
+    e.stopPropagation();
+    var $form = $(this),
+        $btn  = $form.find('button'),
+        $spin = $form.find('.tta-admin-progress-spinner-svg'),
+        $resp = $('#tta-register-response');
+    $resp.removeClass('updated error').text('');
+
+    var email       = $form.find('[name="email"]').val();
+    var emailVerify = $form.find('[name="email_verify"]').val();
+    var pass        = $form.find('[name="password"]').val();
+    var passVerify  = $form.find('[name="password_verify"]').val();
+
+    if(email !== emailVerify){
+      $resp.addClass('error').text( tta_event.email_mismatch_msg );
+      return;
+    }
+
+    if(pass !== passVerify){
+      $resp.addClass('error').text( tta_event.password_mismatch_msg );
+      return;
+    }
+
+    $btn.prop('disabled', true);
+    $spin.show().css({opacity:0}).fadeTo(200,1);
+
+    $.post( tta_ajax.ajax_url, {
+      action: 'tta_register',
+      nonce: tta_ajax.nonce,
+      first_name: $form.find('[name="first_name"]').val(),
+      last_name:  $form.find('[name="last_name"]').val(),
+      email:      email,
+      email_verify: emailVerify,
+      password:   pass,
+      password_verify: passVerify
+    }, function(res){
+      $spin.fadeOut(200);
+      if(res.success){
+        var count = 5;
+        (function update(){
+          $resp.removeClass('error').addClass('updated')
+               .text( tta_event.account_created_msg.replace('%d', count) );
+          if(count-- > 0){
+            setTimeout(update, 1000);
+          } else {
+            window.location.reload();
+          }
+        })();
+      } else {
+        $btn.prop('disabled', false);
+        $resp.addClass('error').text(res.data.message || 'Error');
+      }
+    }, 'json').fail(function(){
+      $spin.fadeOut(200);
+      $btn.prop('disabled', false);
+      $resp.addClass('error').text( tta_event.request_failed_msg );
+    });
+  });
+});

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/ajax/handlers/class-ajax-auth.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/ajax/handlers/class-ajax-auth.php
@@ -34,13 +34,17 @@ class TTA_Ajax_Auth {
         $email        = sanitize_email( $_POST['email']                ?? '' );
         $email_verify = sanitize_email( $_POST['email_verify']         ?? '' );
         $pass         = $_POST['password'] ?? '';
-        if ( ! $first || ! $last || ! $email || ! $email_verify || ! $pass ) {
+        $pass_verify  = $_POST['password_verify'] ?? '';
+        if ( ! $first || ! $last || ! $email || ! $email_verify || ! $pass || ! $pass_verify ) {
             wp_send_json_error( [ 'message' => __( 'All fields are required.', 'tta' ) ] );
         }
         if ( $email !== $email_verify ) {
             wp_send_json_error( [ 'message' => __( 'Emails do not match.', 'tta' ) ] );
         }
-        if ( email_exists( $email ) ) {
+        if ( $pass !== $pass_verify ) {
+            wp_send_json_error( [ 'message' => __( 'Passwords do not match.', 'tta' ) ] );
+        }
+        if ( email_exists( $email ) || tta_get_member_row_by_email( $email ) ) {
             wp_send_json_error( [ 'message' => __( 'Email already in use.', 'tta' ) ] );
         }
         $username = sanitize_user( strstr( $email, '@', true ) );
@@ -69,9 +73,10 @@ class TTA_Ajax_Auth {
                 'last_name'        => $last,
                 'email'            => $email,
                 'joined_at'        => current_time( 'mysql' ),
+                'member_type'      => 'member',
                 'membership_level' => 'free',
             ],
-            [ '%d', '%s', '%s', '%s', '%s', '%s' ]
+            [ '%d', '%s', '%s', '%s', '%s', '%s', '%s' ]
         );
 
         if ( false === $inserted ) {

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/classes/class-tta-assets.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/classes/class-tta-assets.php
@@ -221,6 +221,10 @@ class TTA_Assets {
                     'limit_msg'      => __( "We're sorry, there's a limit of %d per ticket.", 'tta' ),
                     'prev_limit_msg' => __( "We're sorry, there's a limit of %d per ticket. You've already purchased tickets in a previous transaction.", 'tta' ),
                     'sold_out_msg'   => __( "We're sorry, but someone just purchased the last ticket. It's currently reserved in another member's cart.", 'tta' ),
+                    'email_mismatch_msg' => __( 'Email addresses do not match.', 'tta' ),
+                    'password_mismatch_msg' => __( 'Passwords do not match.', 'tta' ),
+                    'request_failed_msg' => __( 'Request failed.', 'tta' ),
+                    'account_created_msg' => __( 'Account created! Reloading in %d…', 'tta' ),
                 ]
             );
         }

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/templates/event-page-template.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/templates/event-page-template.php
@@ -729,9 +729,7 @@ echo '<script type="application/ld+json">' . wp_json_encode( $schema, JSON_UNESC
               printf(
                 /* translators: 1: opening login button, 2: closing login button, 3: opening registration link, 4: closing registration link */
                 esc_html__( 'Ticket discounts may be available! Log in below to check. Don\'t have an account? Create one below or become a Member today!%1$s', 'tta' ),
-                '<div><a href="#tta-login-message" class="tta-button tta-button-primary">
-          Create Account</a><a href="/become-a-member" class="tta-button tta-button-primary">
-          Become a Member</a></div>',
+                '<div><a href="#tta-login-message" class="tta-button tta-button-primary tta-show-register">' . esc_html__( 'Create Account', 'tta' ) . '</a><a href="/become-a-member" class="tta-button tta-button-primary">' . esc_html__( 'Become a Member', 'tta' ) . '</a></div>',
               );
               ?>
             </p>
@@ -754,23 +752,47 @@ $lost_pw_html = sprintf(
 );
 
 // 3. Output form + link
-echo $form_html . $lost_pw_html;
+echo '<div id="tta-login-wrap">' . $form_html . $lost_pw_html . '</div>';
 
+?>
 
-
-
-
-
-
-
-
-
-
-
-
-
-             
-              ?>
+              <form id="tta-register-form" style="display:none;">
+                <p>
+                  <label><?php esc_html_e( 'First Name', 'tta' ); ?><br />
+                    <input type="text" name="first_name" required />
+                  </label>
+                </p>
+                <p>
+                  <label><?php esc_html_e( 'Last Name', 'tta' ); ?><br />
+                    <input type="text" name="last_name" required />
+                  </label>
+                </p>
+                <p>
+                  <label><?php esc_html_e( 'Email', 'tta' ); ?><br />
+                    <input type="email" name="email" required />
+                  </label>
+                </p>
+                <p>
+                  <label><?php esc_html_e( 'Verify Email', 'tta' ); ?><br />
+                    <input type="email" name="email_verify" required />
+                  </label>
+                </p>
+                <p>
+                  <label><?php esc_html_e( 'Password', 'tta' ); ?><br />
+                    <input type="password" name="password" required />
+                  </label>
+                </p>
+                <p>
+                  <label><?php esc_html_e( 'Verify Password', 'tta' ); ?><br />
+                    <input type="password" name="password_verify" required />
+                  </label>
+                </p>
+                <p>
+                  <button type="submit" class="tta-button tta-button-primary"><?php esc_html_e( 'Create Account', 'tta' ); ?></button>
+                  <img class="tta-admin-progress-spinner-svg" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/loading.svg' ); ?>" alt="<?php esc_attr_e( 'Loading…', 'tta' ); ?>" />
+                </p>
+                <span id="tta-register-response" class="tta-admin-progress-response-p"></span>
+              </form>
             </div>
           </div>
         </section>

--- a/docs/EventPage.md
+++ b/docs/EventPage.md
@@ -27,7 +27,9 @@ Returned array keys:
 
 ## Message Center
 
-The Event Page template includes a **Message Center** block under the “About This Event” section. When a visitor is not logged in a small callout invites them to authenticate. The block begins with a **Log in or Register Here** heading followed by a login form that is visible by default. Clicking **Log in here** toggles the embedded form with the same accordion animation used elsewhere on the page. The form submits via `wp_login_form()` and redirects back to the event page on success. A link to the standard registration page is also provided.
+The Event Page template includes a **Message Center** block under the “About This Event” section. When a visitor is not logged in a small callout invites them to authenticate. The block begins with a **Log in or Register Here** heading followed by a login form that is visible by default. Clicking **Log in here** toggles the embedded form with the same accordion animation used elsewhere on the page.
+
+Guests can now create a free account directly within this block. Selecting **Create Account** fades out the login form and reveals a registration form requesting first name, last name, email (entered twice for verification), and password (also entered twice). A progress spinner and response area provide feedback. The form checks that the email and password fields match and ensures no existing WordPress user or member already uses the email address. On success, a confirmation message displays a five‑second countdown before the page reloads and automatically logs the new member in.
 
 ## Event Type and Ticket Context
 


### PR DESCRIPTION
## Summary
- add "Create Account" registration form to event page that slides in when triggered
- validate email and password fields server-side and create member record with free membership
- provide JS handler for registration with spinner, feedback and auto-reload

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_688b6e8ddfc883209dfaa14a132e72e9