### PR TITLE
fix refunded attendee display and summary counts

### DIFF
--- a/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
@@ -2352,6 +2352,20 @@ function tta_get_member_history_summary( $member_id ) {
 
     $summary['events'] = count( array_unique( $event_ids ) );
 
+    // Subtract any refunds issued to the member.
+    $refund_rows = $wpdb->get_results(
+        $wpdb->prepare(
+            "SELECT action_data FROM {$hist_table} WHERE member_id = %d AND action_type = 'refund'",
+            $member_id
+        ),
+        ARRAY_A
+    );
+    foreach ( $refund_rows as $row ) {
+        $data   = json_decode( $row['action_data'], true );
+        $amount = floatval( $data['amount'] ?? 0 );
+        $summary['total_spent'] -= $amount;
+    }
+
     $status_rows = $wpdb->get_results(
         $wpdb->prepare(
             "SELECT a.status FROM {$att_table} a
@@ -2370,7 +2384,7 @@ function tta_get_member_history_summary( $member_id ) {
     }
 
     $summary['refunds'] = (int) $wpdb->get_var( $wpdb->prepare(
-        "SELECT COUNT(*) FROM {$hist_table} WHERE member_id = %d AND action_type = 'refund_request'",
+        "SELECT COUNT(*) FROM {$hist_table} WHERE member_id = %d AND action_type = 'refund'",
         $member_id
     ) );
 
@@ -2633,6 +2647,15 @@ function tta_get_refund_requests() {
     foreach ( $rows as $r ) {
         $data = json_decode( $r['action_data'], true );
         $att = $data['attendee'] ?? [];
+        $attendee = [
+            'id'          => intval( $att['id'] ?? 0 ),
+            'first_name'  => sanitize_text_field( $att['first_name'] ?? '' ),
+            'last_name'   => sanitize_text_field( $att['last_name'] ?? '' ),
+            'email'       => sanitize_email( $att['email'] ?? '' ),
+            'phone'       => sanitize_text_field( $att['phone'] ?? '' ),
+            'amount_paid' => isset( $att['amount_paid'] ) ? floatval( $att['amount_paid'] ) : 0,
+        ];
+
         $out[] = [
             'date'          => $r['action_date'],
             'member_id'     => intval( $r['member_id'] ),
@@ -2643,12 +2666,13 @@ function tta_get_refund_requests() {
             'transaction_id'=> sanitize_text_field( $data['transaction_id'] ?? '' ),
             'ticket_id'     => intval( $data['ticket_id'] ?? 0 ),
             'reason'        => sanitize_text_field( $data['reason'] ?? '' ),
-            'attendee_id'   => intval( $att['id'] ?? 0 ),
-            'first_name'    => sanitize_text_field( $att['first_name'] ?? '' ),
-            'last_name'     => sanitize_text_field( $att['last_name'] ?? '' ),
-            'email'         => sanitize_email( $att['email'] ?? '' ),
-            'phone'         => sanitize_text_field( $att['phone'] ?? '' ),
-            'amount_paid'   => isset( $att['amount_paid'] ) ? floatval( $att['amount_paid'] ) : 0,
+            'attendee_id'   => $attendee['id'],
+            'first_name'    => $attendee['first_name'],
+            'last_name'     => $attendee['last_name'],
+            'email'         => $attendee['email'],
+            'phone'         => $attendee['phone'],
+            'amount_paid'   => $attendee['amount_paid'],
+            'attendee'      => $attendee,
         ];
     }
 

--- a/app/public/wp-content/plugins/tta-management-plugin/tests/HelpersTest.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/tests/HelpersTest.php
@@ -649,6 +649,8 @@ class HelpersTest extends TestCase {
         $this->assertSame('a@example.com', $rows[0]['email']);
         $this->assertSame(10.0, $rows[0]['amount_paid']);
         $this->assertSame(55, $rows[0]['attendee_id']);
+        $this->assertArrayHasKey('attendee', $rows[0]);
+        $this->assertSame('Ann', $rows[0]['attendee']['first_name']);
         $this->assertSame(1, $wpdb->results_calls);
         $cached = tta_get_refund_requests();
         $this->assertSame(1, $wpdb->results_calls);

--- a/docs/MemberHistoryAdmin.md
+++ b/docs/MemberHistoryAdmin.md
@@ -9,7 +9,7 @@ An **Export Members** form lets administrators download a spreadsheet with the s
 - Count of events they have purchased
 - Count of events checked in
 - Count of no‑shows
-- Number of refund or cancellation requests
+- Number of refunds or cancellation requests
 - A complete payment history table including event purchases and membership charges
 - Membership cancellation entries noting who performed the action and the last four digits of the card
 - Any private notes stored with the member record appear in the expanded detail view rather than as a table column


### PR DESCRIPTION
## Summary
- ensure refund requests retain attendee details for display and purchaser detection
- account for refunds in member summary totals and counts
- document refund metrics and cover with unit test

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_688b900e6634832085448cf1583b3069