### PR TITLE
Prevent early release of refund tickets

### DIFF
--- a/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
@@ -4341,6 +4341,33 @@ function tta_decrement_released_refund_count( $ticket_id, $diff = 1 ) {
 }
 
 /**
+ * Determine if an event has any active cart reservations.
+ *
+ * @param string $event_ute_id Event ute_id.
+ * @return bool True when unexpired cart items exist.
+ */
+function tta_event_has_active_cart_reservations( $event_ute_id ) {
+    global $wpdb;
+    $event_ute_id = sanitize_text_field( $event_ute_id );
+    if ( '' === $event_ute_id ) {
+        return false;
+    }
+    $cart_table    = $wpdb->prefix . 'tta_cart_items';
+    $tickets_table = $wpdb->prefix . 'tta_tickets';
+
+    $count = (int) $wpdb->get_var(
+        $wpdb->prepare(
+            "SELECT COUNT(*) FROM {$cart_table} ci
+             JOIN {$tickets_table} t ON ci.ticket_id = t.id
+             WHERE t.event_ute_id = %s AND ci.expires_at > NOW()",
+            $event_ute_id
+        )
+    );
+
+    return $count > 0;
+}
+
+/**
  * Release tickets from the refund pool when an event sells out.
  *
  * @param string $event_ute_id Event ute_id.
@@ -4356,6 +4383,10 @@ function tta_release_refund_tickets( $event_ute_id ) {
     }
     $events_table  = $wpdb->prefix . 'tta_events';
     $tickets_table = $wpdb->prefix . 'tta_tickets';
+
+    if ( tta_event_has_active_cart_reservations( $event_ute_id ) ) {
+        return;
+    }
 
     $event_id = tta_get_event_id_by_ute( $event_ute_id );
     if ( ! $event_id ) {

--- a/app/public/wp-content/plugins/tta-management-plugin/tests/RefundTicketReleaseTest.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/tests/RefundTicketReleaseTest.php
@@ -1,0 +1,51 @@
+<?php
+use PHPUnit\Framework\TestCase;
+if (!defined('ARRAY_A')) { define('ARRAY_A','ARRAY_A'); }
+
+class DummyWpdbRefund {
+    public $prefix = 'wp_';
+    public $data = [];
+    public function prepare($q,...$a){
+        foreach($a as $v){ $q=preg_replace('/%d/',$v,$q,1); $q=preg_replace('/%s/',$v,$q,1); }
+        return $q;
+    }
+    public function get_var($query){
+        if (strpos($query, 'FROM wp_tta_events') !== false) {
+            return 11; // event id
+        }
+        if (strpos($query, 'FROM wp_tta_cart_items') !== false) {
+            return count($this->data['wp_tta_cart_items']);
+        }
+        return null;
+    }
+    public function get_results($query,$output=ARRAY_A){
+        if (strpos($query, 'FROM wp_tta_tickets') !== false) {
+            return $this->data['wp_tta_tickets'];
+        }
+        return [];
+    }
+    public function query($query){
+        if (preg_match('/UPDATE wp_tta_tickets SET ticketlimit = ticketlimit \+ (\d+) WHERE id = (\d+)/',$query,$m)){
+            $diff=intval($m[1]); $id=intval($m[2]);
+            foreach($this->data['wp_tta_tickets'] as &$row){ if($row['id']==$id){ $row['ticketlimit'] += $diff; }}
+        }
+    }
+}
+
+class RefundTicketReleaseTest extends TestCase {
+    protected function setUp(): void {
+        if (!defined('ABSPATH')) { define('ABSPATH', __DIR__); }
+        require_once __DIR__ . '/../includes/helpers.php';
+        global $wpdb;
+        $wpdb = new DummyWpdbRefund();
+        $wpdb->data['wp_tta_tickets'] = [ ['id'=>1,'event_ute_id'=>'ev1','ticketlimit'=>0] ];
+        $wpdb->data['wp_tta_cart_items'] = [ ['ticket_id'=>1,'expires_at'=>date('Y-m-d H:i:s', time()+300)] ];
+    }
+
+    public function test_event_has_active_cart_reservations(){
+        $this->assertTrue( tta_event_has_active_cart_reservations('ev1') );
+        global $wpdb;
+        $wpdb->data['wp_tta_cart_items'] = [];
+        $this->assertFalse( tta_event_has_active_cart_reservations('ev1') );
+    }
+}

--- a/docs/RefundRequestsAdmin.md
+++ b/docs/RefundRequestsAdmin.md
@@ -5,4 +5,6 @@ The **TTA Refund Requests** admin screen lists every refund submitted from a mem
 If a member purchased multiple tickets in the same transaction the request specifies the ticket ID so only the relevant attendee(s) appear in the table.
 
 After a refund request the attendee is removed but the ticket is held in a refund pool rather than adding back to inventory. Tickets from this pool are only released once all regular tickets sell out. The member is not refunded until one of these pooled tickets is purchased by another attendee. Clicking **Refund Now** processes the refund immediately and returns the seat to the normal inventory.
+
+Pending refund tickets are never offered while a last remaining seat is merely reserved in someone's cart. Inventory from the refund pool is released only after the final standard ticket has been successfully purchased with no outstanding cart reservations.
 Processed requests disappear from the list once the refund is issued or the request expires. Any requests still pending within two hours of the event are removed without a refund.


### PR DESCRIPTION
## Summary
- avoid releasing refund-pool tickets while an event’s last seat is only held in a cart
- document refund-pool handling for cart reservations
- add test covering active cart reservation checks

## Testing
- `composer install`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_688f9f0fc7d88320b2312815deaf5158