### PR TITLE
feat: support tokens in link helper for email templates

### DIFF
--- a/app/public/wp-content/plugins/tta-management-plugin/assets/js/backend/admin.js
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/js/backend/admin.js
@@ -1172,6 +1172,32 @@ $(document).on('click', '.tta-remove-waitlist-entry', function(e){
     if (activeField) { $(activeField).trigger('blur'); }
   });
 
+  $(document).on('click', '.tta-link-text', function(){
+    if (!activeField) { return; }
+    var field = activeField;
+    if (field.selectionStart === undefined || field.selectionEnd === undefined) { return; }
+    if (field.selectionStart === field.selectionEnd) { return; }
+    var start = field.selectionStart;
+    var end   = field.selectionEnd;
+    var val   = field.value;
+    // If user selected inside a token, expand to include braces.
+    if (start > 0 && val[start - 1] === '{' && val[end] === '}') {
+      start--;
+      end++;
+    }
+    var sel = val.substring(start, end);
+    var url = prompt('Enter URL or token');
+    if (!url) { return; }
+    url = url.trim();
+    if (url && url[0] !== '{' && !/^[a-z]+:\/\//i.test(url) && url[0] !== '/' && url[0] !== '#') {
+      url = '{' + url.replace(/^\{?|\}?$/g, '') + '}';
+    }
+    var md = '[' + sel + '](' + url + ')';
+    field.value = val.substring(0, start) + md + val.substring(end);
+    field.selectionStart = field.selectionEnd = start + md.length;
+    $(field).trigger('blur');
+  });
+
   function convertLinks(text){
     return text.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>');
   }
@@ -1193,6 +1219,7 @@ $(document).on('click', '.tta-remove-waitlist-entry', function(e){
     var map  = {
         '{event_name}': ev.name || 'Sample Event',
         '{event_address}': ev.address || '123 Main St',
+        '{event_address_link}': ev.address_link || '#',
         '{event_link}': ev.page_url || '#',
         '{dashboard_profile_url}': ev.dashboard_profile_url || '#',
         '{dashboard_upcoming_url}': ev.dashboard_upcoming_url || '#',

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-comms-admin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-comms-admin.php
@@ -200,6 +200,7 @@ class TTA_Comms_Admin {
             echo '<span class="tta-tooltip-icon" data-tooltip="' . esc_attr__( 'Details about the event.', 'tta' ) . '"></span><br>';
             echo '<button type="button" class="button tta-insert-token" data-token="{event_name}">{event_name}</button> ';
             echo '<button type="button" class="button tta-insert-token" data-token="{event_address}">{event_address}</button> ';
+            echo '<button type="button" class="button tta-insert-token" data-token="{event_address_link}">{event_address_link}</button> ';
             echo '<button type="button" class="button tta-insert-token" data-token="{event_link}">{event_link}</button> ';
             echo '<button type="button" class="button tta-insert-token" data-token="{event_date}">{event_date}</button> ';
             echo '<button type="button" class="button tta-insert-token" data-token="{event_time}">{event_time}</button> ';
@@ -251,7 +252,8 @@ class TTA_Comms_Admin {
             echo '<button type="button" class="button tta-insert-token" data-token="{refund_event_date}">{refund_event_date}</button> ';
             echo '<button type="button" class="button tta-insert-token" data-token="{refund_event_time}">{refund_event_time}</button></div>';
 
-            echo '<button type="button" class="button tta-insert-br">Line Break</button>';
+            echo '<button type="button" class="button tta-link-text">' . esc_html__( 'Link This Text', 'tta' ) . '</button>';
+            echo '<button type="button" class="button tta-insert-br">' . esc_html__( 'Line Break', 'tta' ) . '</button>';
             echo '</td></tr>';
             echo '<tr><th scope="row">' . esc_html__( 'Email Preview', 'tta' ) . '</th><td><div class="tta-email-preview"><strong class="tta-email-preview-subject"></strong><p class="tta-email-preview-body"></p></div></td></tr>';
             echo '<tr><th scope="row">' . esc_html__( 'SMS Preview', 'tta' ) . '</th><td><div class="tta-sms-preview"></div></td></tr>';

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/classes/class-tta-assets.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/classes/class-tta-assets.php
@@ -135,6 +135,7 @@ class TTA_Assets {
                         $e['dashboard_waitlist_url'] = home_url( '/member-dashboard/?tab=waitlist' );
                         $e['dashboard_past_url']    = home_url( '/member-dashboard/?tab=past' );
                         $e['dashboard_billing_url'] = home_url( '/member-dashboard/?tab=billing' );
+                        $e['address_link']          = $e['address'] ? esc_url( 'https://maps.google.com/?q=' . rawurlencode( $e['address'] ) ) : '';
                         $e['date']                  = $e['date_formatted'];
                         $e['time']                  = $e['time_formatted'];
                         return $e;

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/email/class-email-handler.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/email/class-email-handler.php
@@ -118,6 +118,9 @@ class TTA_Email_Handler {
         $tokens = [
             '{event_name}'           => $event['name'] ?? '',
             '{event_address}'        => $event['address'] ?? '',
+            '{event_address_link}'   => isset( $event['address'] ) && $event['address'] !== ''
+                ? esc_url( 'https://maps.google.com/?q=' . rawurlencode( $event['address'] ) )
+                : '',
             '{event_link}'           => $event['page_url'] ?? '',
             '{dashboard_profile_url}'  => home_url( '/member-dashboard/?tab=profile' ),
             '{dashboard_upcoming_url}' => home_url( '/member-dashboard/?tab=upcoming' ),

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
@@ -4784,6 +4784,9 @@ function tta_send_assistance_note_email( $event_ute_id, $wp_user_id, $note ) {
     $tokens = [
         '{event_name}'           => $event['name'] ?? '',
         '{event_address}'        => $event['address'] ?? '',
+        '{event_address_link}'   => isset( $event['address'] ) && $event['address'] !== ''
+            ? esc_url( 'https://maps.google.com/?q=' . rawurlencode( $event['address'] ) )
+            : '',
         '{event_link}'           => $event['page_url'] ?? '',
         '{dashboard_profile_url}'  => home_url( '/member-dashboard/?tab=profile' ),
         '{dashboard_upcoming_url}' => home_url( '/member-dashboard/?tab=upcoming' ),

--- a/app/public/wp-content/plugins/tta-management-plugin/tests/EmailTokensTest.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/tests/EmailTokensTest.php
@@ -16,6 +16,9 @@ class EmailTokensTest extends TestCase {
         if (!function_exists('date_i18n')) {
             function date_i18n($f,$ts){ return date($f,$ts); }
         }
+        if (!function_exists('esc_url')) {
+            function esc_url($v){ return $v; }
+        }
         require_once __DIR__ . '/../includes/helpers.php';
         require_once __DIR__ . '/../includes/email/class-email-handler.php';
     }
@@ -58,5 +61,35 @@ class EmailTokensTest extends TestCase {
 
         $this->assertSame('Tucker', $tokens1['{attendee_first_name}']);
         $this->assertSame('Jill', $tokens2['{attendee_first_name}']);
+    }
+
+    public function test_build_tokens_includes_event_address_link() {
+        $handler = TTA_Email_Handler::get_instance();
+        $ref = new \ReflectionClass($handler);
+        $method = $ref->getMethod('build_tokens');
+        $method->setAccessible(true);
+
+        $event = [
+            'name'    => 'Event',
+            'date'    => '2025-06-30',
+            'time'    => '18:00|20:00',
+            'address' => '500 Sample St, Richmond VA',
+        ];
+        $member = [
+            'first_name' => 'Bob',
+            'last_name'  => 'Smith',
+            'user_email' => 'bob@example.com',
+            'member'     => [],
+            'membership_level' => '',
+        ];
+        $attendees = [];
+
+        $tokens = $method->invoke($handler, $event, $member, $attendees);
+
+        $this->assertArrayHasKey('{event_address_link}', $tokens);
+        $this->assertSame(
+            'https://maps.google.com/?q=500%20Sample%20St%2C%20Richmond%20VA',
+            $tokens['{event_address_link}']
+        );
     }
 }

--- a/app/public/wp-content/plugins/tta-management-plugin/tests/HelpersTest.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/tests/HelpersTest.php
@@ -974,6 +974,28 @@ class HelpersTest extends TestCase {
         $this->assertSame( $out, tta_convert_links( $in ) );
     }
 
+    public function test_convert_links_handles_tokens() {
+        require_once __DIR__ . '/../includes/helpers.php';
+        $tokens = [
+            '{event_name}' => 'Roller Skating #2',
+            '{event_link}' => 'https://example.com/roller-skating-2/',
+        ];
+        $in  = '[{event_name}]({event_link})';
+        $out = '<a href="https://example.com/roller-skating-2/">Roller Skating #2</a>';
+        $this->assertSame( $out, tta_convert_links( strtr( $in, $tokens ) ) );
+    }
+
+    public function test_convert_links_handles_address_tokens() {
+        require_once __DIR__ . '/../includes/helpers.php';
+        $tokens = [
+            '{event_address}' => '500 Sample St',
+            '{event_address_link}' => 'https://maps.google.com/?q=500+Sample+St',
+        ];
+        $in  = '[{event_address}]({event_address_link})';
+        $out = '<a href="https://maps.google.com/?q=500+Sample+St">500 Sample St</a>';
+        $this->assertSame( $out, tta_convert_links( strtr( $in, $tokens ) ) );
+    }
+
     public function test_expand_anchor_tokens_handles_anchor() {
         require_once __DIR__ . '/../includes/helpers.php';
         $tokens = [ '{dashboard_upcoming_url}' => 'http://example.com/member-dashboard/?tab=upcoming' ];

--- a/docs/EmailSMS.md
+++ b/docs/EmailSMS.md
@@ -55,6 +55,7 @@ Buttons labelled with tokens (e.g. `{event_name}`) insert placeholders into the 
 ```
 {event_name}
 {event_address}
+{event_address_link}
 {event_link}
 {dashboard_profile_url}
 {dashboard_upcoming_url}
@@ -70,6 +71,8 @@ Buttons labelled with tokens (e.g. `{event_name}`) insert placeholders into the 
 {member_cost}
 {premium_cost}
 ```
+
+`{event_address_link}` outputs a Google Maps URL for the event address.
 
 Dashboard URL tokens accept an optional `anchor` attribute. For example:
 
@@ -133,7 +136,9 @@ Use the **Line Break** button to insert a newline. Email previews render these b
 
 ### Hyperlinks
 
-Template text can include Markdown-style links in the form `[Link Text](https://example.com)`. When emails are sent these are converted to clickable `<a>` tags. This works for any URL, including tokens like `{dashboard_upcoming_url}`.
+Template text can include Markdown-style links in the form `[Link Text](https://example.com)`. When emails are sent these are converted to clickable `<a>` tags. Both the link text and the URL can be tokens, so `[{event_name}]({event_link})` resolves to a link with the event name and URL.
+
+Use the **Link This Text** button below the template fields to create these links without typing the Markdown. Highlight any text or token in the email body, click the button, and paste a URL or token. The selected text becomes the anchor for the provided link, and tokens are substituted when the email is sent.
 
 ### Formatting Helpers
 


### PR DESCRIPTION
## Summary
- let "Link This Text" button wrap tokens and auto-add braces for token URLs
- document that both anchor text and href may be tokens
- add unit test ensuring token links expand to HTML
- add `{event_address_link}` token and button to turn event addresses into map links

## Testing
- `sudo apt-get update`
- `sudo apt-get install -y php-cli`
- `composer install`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689209cb9d508320a5cbf001d3d618f3