### PR TITLE
Add host and volunteer tokens for emails

### DIFF
--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-comms-admin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-comms-admin.php
@@ -242,6 +242,11 @@ class TTA_Comms_Admin {
             echo '<button type="button" class="button tta-insert-token" data-token="{attendee4_email}">{attendee4_email}</button> ';
             echo '<button type="button" class="button tta-insert-token" data-token="{attendee4_phone}">{attendee4_phone}</button></div>';
 
+            echo '<div class="tta-token-section"><span class="tta-tooltip-icon" data-tooltip="' . esc_attr__( 'Event hosts and volunteers.', 'tta' ) . '"><img src="' . esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ) . '" alt="?"></span><strong>' . esc_html__( 'Event Contacts', 'tta' ) . '</strong><br>';
+            echo '<button type="button" class="button tta-insert-token" data-token="{event_host}">{event_host}</button> ';
+            echo '<button type="button" class="button tta-insert-token" data-token="{event_volunteer}">{event_volunteer}</button> ';
+            echo '<button type="button" class="button tta-insert-token" data-token="{host_notes}">{host_notes}</button></div>';
+
             echo '<div class="tta-token-section"><span class="tta-tooltip-icon" data-tooltip="' . esc_attr__( 'Details about the refunded ticket.', 'tta' ) . '"><img src="' . esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ) . '" alt="?"></span><strong>' . esc_html__( 'Refund Information', 'tta' ) . '</strong><br>';
             echo '<button type="button" class="button tta-insert-token" data-token="{refund_first_name}">{refund_first_name}</button> ';
             echo '<button type="button" class="button tta-insert-token" data-token="{refund_last_name}">{refund_last_name}</button> ';

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/email/class-email-handler.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/email/class-email-handler.php
@@ -143,6 +143,13 @@ class TTA_Email_Handler {
             '{member_type}'          => $member['member']['member_type'] ?? '',
         ];
 
+        $names = tta_get_event_host_volunteer_names( $event['id'] ?? 0 );
+        $tokens['{event_host}']       = implode( ', ', $names['hosts'] );
+        $tokens['{event_hosts}']      = $tokens['{event_host}'];
+        $tokens['{event_volunteer}']  = implode( ', ', $names['volunteers'] );
+        $tokens['{event_volunteers}'] = $tokens['{event_volunteer}'];
+        $tokens['{host_notes}']       = $event['host_notes'] ?? '';
+
         for ( $i = 0; $i < 4; $i++ ) {
             $a = $attendees[ $i ] ?? [];
             $index = $i === 0 ? '' : ( $i + 1 );

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
@@ -970,6 +970,77 @@ function tta_get_event_host_volunteer_emails( $event_id ) {
 }
 
 /**
+ * Retrieve host and volunteer names for an event.
+ *
+ * Supports numeric user IDs and legacy name-based values.
+ *
+ * @param int $event_id Event ID.
+ * @return array {
+ *     @type string[] $hosts      Host names.
+ *     @type string[] $volunteers Volunteer names.
+ * }
+ */
+function tta_get_event_host_volunteer_names( $event_id ) {
+    $event_id = intval( $event_id );
+    if ( ! $event_id ) {
+        return [ 'hosts' => [], 'volunteers' => [] ];
+    }
+
+    $cache_key = 'event_host_vol_names_' . $event_id;
+    $cached    = TTA_Cache::get( $cache_key );
+    if ( false !== $cached ) {
+        return $cached;
+    }
+
+    global $wpdb;
+    $events_table  = $wpdb->prefix . 'tta_events';
+    $archive_table = $wpdb->prefix . 'tta_events_archive';
+
+    $row = $wpdb->get_row(
+        $wpdb->prepare( "SELECT hosts, volunteers FROM {$events_table} WHERE id = %d", $event_id ),
+        ARRAY_A
+    );
+    if ( ! $row ) {
+        $row = $wpdb->get_row(
+            $wpdb->prepare( "SELECT hosts, volunteers FROM {$archive_table} WHERE id = %d", $event_id ),
+            ARRAY_A
+        );
+    }
+    if ( ! $row ) {
+        TTA_Cache::set( $cache_key, [ 'hosts' => [], 'volunteers' => [] ], 60 );
+        return [ 'hosts' => [], 'volunteers' => [] ];
+    }
+
+    $parse = static function( $list ) {
+        $ids = [];
+        $names = [];
+        foreach ( array_filter( array_map( 'trim', explode( ',', (string) $list ) ) ) as $val ) {
+            if ( ctype_digit( $val ) ) {
+                $ids[] = intval( $val );
+            } else {
+                $names[] = sanitize_text_field( $val );
+            }
+        }
+        return [ $ids, $names ];
+    };
+
+    list( $host_ids, $host_names ) = $parse( $row['hosts'] ?? '' );
+    list( $vol_ids,  $vol_names  ) = $parse( $row['volunteers'] ?? '' );
+
+    $host_list = array_merge( tta_get_member_names_by_ids( $host_ids ), $host_names );
+    $vol_list  = array_merge( tta_get_member_names_by_ids( $vol_ids ), $vol_names );
+
+    $data = [
+        'hosts'      => array_values( array_unique( array_filter( $host_list ) ) ),
+        'volunteers' => array_values( array_unique( array_filter( $vol_list ) ) ),
+    ];
+
+    $ttl = ( empty( $data['hosts'] ) && empty( $data['volunteers'] ) ) ? 60 : 300;
+    TTA_Cache::set( $cache_key, $data, $ttl );
+    return $data;
+}
+
+/**
  * Convert an array of member names to WordPress user IDs.
  *
  * Matching is case-insensitive on the concatenated first and last name.

--- a/app/public/wp-content/plugins/tta-management-plugin/tests/EmailTokensTest.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/tests/EmailTokensTest.php
@@ -92,4 +92,34 @@ class EmailTokensTest extends TestCase {
             $tokens['{event_address_link}']
         );
     }
+
+    public function test_build_tokens_include_host_and_volunteer_tokens() {
+        $handler = TTA_Email_Handler::get_instance();
+        $ref = new \ReflectionClass($handler);
+        $method = $ref->getMethod('build_tokens');
+        $method->setAccessible(true);
+
+        $event = [
+            'id'         => 0,
+            'name'       => 'Event',
+            'date'       => '2025-06-30',
+            'time'       => '18:00|20:00',
+            'host_notes' => 'Bring snacks',
+        ];
+        $member = [
+            'first_name' => 'Bob',
+            'last_name'  => 'Smith',
+            'user_email' => 'bob@example.com',
+            'member'     => [],
+            'membership_level' => '',
+        ];
+        $attendees = [];
+
+        $tokens = $method->invoke($handler, $event, $member, $attendees);
+
+        $this->assertArrayHasKey('{event_host}', $tokens);
+        $this->assertArrayHasKey('{event_volunteer}', $tokens);
+        $this->assertArrayHasKey('{host_notes}', $tokens);
+        $this->assertSame('Bring snacks', $tokens['{host_notes}']);
+    }
 }

--- a/docs/EmailSMS.md
+++ b/docs/EmailSMS.md
@@ -119,6 +119,14 @@ empty or omitted the full URL is printed.
 
 Each attendee receives a personalized email where these tokens reflect their own details.
 
+### Host & Volunteer Information
+
+```
+{event_host}
+{event_volunteer}
+{host_notes}
+```
+
 ### Refund Information
 
 ```


### PR DESCRIPTION
## Summary
- support `{event_host}`, `{event_volunteer}`, `{host_notes}` tokens in communications
- expose new host/volunteer token buttons in Email & SMS admin
- document and test new tokens

## Testing
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689231854e148320aca77cd5a8e50a63