### PR TITLE
Fix apostrophe handling in email previews

### DIFF
--- a/app/public/wp-content/plugins/tta-management-plugin/assets/js/backend/admin.js
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/js/backend/admin.js
@@ -1238,6 +1238,9 @@ $(document).on('click', '.tta-remove-waitlist-entry', function(e){
     var subj = $form.find('input[name=email_subject]').val() || '';
     var body = $form.find('textarea[name=email_body]').val() || '';
     var sms  = $form.find('textarea[name=sms_text]').val() || '';
+    subj = subj.replace(/\\'/g, "'");
+    body = body.replace(/\\'/g, "'");
+    sms  = sms.replace(/\\'/g, "'");
     var ev   = TTA_Ajax.sample_event || {};
     var mem  = TTA_Ajax.sample_member || {};
     var map  = {
@@ -1290,6 +1293,9 @@ $(document).on('click', '.tta-remove-waitlist-entry', function(e){
     body = expandAnchors(body, map);
     Object.keys(map).forEach(function(tok){
       var val = map[tok];
+      if (typeof val === 'string') {
+        val = val.replace(/\\'/g, "'");
+      }
       subj = subj.split(tok).join(val);
       body = body.split(tok).join(val);
       sms  = sms.split(tok).join(val);

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-comms-admin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-comms-admin.php
@@ -46,22 +46,13 @@ class TTA_Comms_Admin {
                 'email_body'  => __('Your event is only 2 hours away! Below are the details.', 'tta'),
                 'sms_text'    => __('Only 2 hours to go! View your upcoming events at ', 'tta'),
             ],
-            'new_event' => [
-                'label'       => __('New Event Created', 'tta'),
-                'type'        => 'Internal',
-                'category'    => 'Admin Notice',
-                'description' => __('Notifies administrators when a new event is created.', 'tta'),
-                'email_subject' => __('New event created', 'tta'),
-                'email_body'  => __('A new event has been added to the calendar. Details are below.', 'tta'),
-                'sms_text'    => '',
-            ],
             'refund_requested' => [
                 'label'       => __('Refund Requested', 'tta'),
-                'type'        => 'Internal',
-                'category'    => 'Admin Notice',
-                'description' => __('Alert when a member requests a refund.', 'tta'),
+                'type'        => 'External',
+                'category'    => 'Refund',
+                'description' => __('Sent to a member when they request a refund.', 'tta'),
                 'email_subject' => __('Refund request received', 'tta'),
-                'email_body'  => __('A member has requested a refund for the event below.', 'tta'),
+                'email_body'  => __('We received your refund request for the event below. Our team will review and follow up soon.', 'tta'),
                 'sms_text'    => '',
             ],
             'refund_processed' => [
@@ -260,7 +251,7 @@ class TTA_Comms_Admin {
             echo '<div class="tta-token-section"><strong>' . esc_html__( 'Formatting & Styling', 'tta' ) . '</strong><br>';
             echo '<button type="button" class="button tta-link-text">' . esc_html__( 'Link This Text', 'tta' ) . '</button> ';
             echo '<button type="button" class="button tta-insert-br">' . esc_html__( 'Line Break', 'tta' ) . '</button> ';
-            echo '<button type="button" class="button tta-bold-text">' . esc_html__( 'bold', 'tta' ) . '</button></div>';
+            echo '<button type="button" class="button tta-bold-text">' . esc_html__( 'Bold', 'tta' ) . '</button></div>';
 
             echo '</td></tr>';
             echo '<tr><th scope="row">' . esc_html__( 'Email Preview', 'tta' ) . '</th><td><div class="tta-email-preview"><strong class="tta-email-preview-subject"></strong><p class="tta-email-preview-body"></p></div></td></tr>';

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/ajax/handlers/class-ajax-events.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/ajax/handlers/class-ajax-events.php
@@ -65,7 +65,7 @@ class TTA_Ajax_Events {
             'otherimageids'        => tta_sanitize_text_field( $_POST['otherimageids']       ?? '' ),
             'hosts'                => implode( ',', tta_get_member_ids_by_names( $_POST['hosts'] ?? [] ) ),
             'volunteers'           => implode( ',', tta_get_member_ids_by_names( $_POST['volunteers'] ?? [] ) ),
-            'host_notes'           => sanitize_textarea_field( $_POST['host_notes'] ?? '' ),
+            'host_notes'           => tta_sanitize_textarea_field( $_POST['host_notes'] ?? '' ),
         ];
 
         $required = [
@@ -247,7 +247,7 @@ class TTA_Ajax_Events {
             'otherimageids'        => tta_sanitize_text_field( $_POST['otherimageids']       ?? '' ),
             'hosts'                => implode( ',', tta_get_member_ids_by_names( $_POST['hosts'] ?? [] ) ),
             'volunteers'           => implode( ',', tta_get_member_ids_by_names( $_POST['volunteers'] ?? [] ) ),
-            'host_notes'           => sanitize_textarea_field( $_POST['host_notes'] ?? '' ),
+            'host_notes'           => tta_sanitize_textarea_field( $_POST['host_notes'] ?? '' ),
         ];
 
         $updated = $wpdb->update( $events_table, $event_data, [ 'id' => $id ] );

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/email/class-email-handler.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/email/class-email-handler.php
@@ -148,7 +148,7 @@ class TTA_Email_Handler {
         $tokens['{event_hosts}']      = $tokens['{event_host}'];
         $tokens['{event_volunteer}']  = $names['volunteers'] ? implode( ', ', $names['volunteers'] ) : 'TBD';
         $tokens['{event_volunteers}'] = $tokens['{event_volunteer}'];
-        $tokens['{host_notes}']       = $event['host_notes'] ?? '';
+        $tokens['{host_notes}']       = tta_unslash( $event['host_notes'] ?? '' );
 
         for ( $i = 0; $i < 4; $i++ ) {
             $a = $attendees[ $i ] ?? [];

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
@@ -3416,7 +3416,7 @@ function tta_get_next_event() {
     $names = tta_get_event_host_volunteer_names( $event['id'] );
     $event['host_names']       = implode( ', ', $names['hosts'] );
     $event['volunteer_names']  = implode( ', ', $names['volunteers'] );
-    $event['host_notes']       = sanitize_textarea_field( $row['host_notes'] ?? '' );
+    $event['host_notes']       = tta_sanitize_textarea_field( $row['host_notes'] ?? '' );
 
     TTA_Cache::set( $cache_key, $event, 300 );
     return $event;
@@ -3481,7 +3481,7 @@ function tta_get_event_for_email( $event_ute_id ) {
         'base_cost'    => floatval( $row['baseeventcost'] ),
         'member_cost'  => floatval( $row['discountedmembercost'] ),
         'premium_cost' => floatval( $row['premiummembercost'] ),
-        'host_notes'   => sanitize_textarea_field( $row['host_notes'] ),
+        'host_notes'   => tta_sanitize_textarea_field( $row['host_notes'] ),
     ];
 
     TTA_Cache::set( $cache_key, $event, 300 );

--- a/app/public/wp-content/plugins/tta-management-plugin/tests/EmailTokensTest.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/tests/EmailTokensTest.php
@@ -104,7 +104,7 @@ class EmailTokensTest extends TestCase {
             'name'       => 'Event',
             'date'       => '2025-06-30',
             'time'       => '18:00|20:00',
-            'host_notes' => 'Bring snacks',
+            'host_notes' => 'Don\'t forget snacks',
         ];
         $member = [
             'first_name' => 'Bob',
@@ -122,6 +122,6 @@ class EmailTokensTest extends TestCase {
         $this->assertArrayHasKey('{host_notes}', $tokens);
         $this->assertSame('TBD', $tokens['{event_host}']);
         $this->assertSame('TBD', $tokens['{event_volunteer}']);
-        $this->assertSame('Bring snacks', $tokens['{host_notes}']);
+        $this->assertSame("Don't forget snacks", $tokens['{host_notes}']);
     }
 }

--- a/docs/EmailSMS.md
+++ b/docs/EmailSMS.md
@@ -9,8 +9,7 @@ The plugin sends automated notifications to members. Administrators can edit the
 | `purchase` | Sent after a successful event purchase. Includes event details automatically. |
 | `reminder_24hr` | Sent 24 hours before an event starts. |
 | `reminder_2hr` | Sent two hours before an event starts. |
-| `new_event` | Internal notice when a new event is created. |
-| `refund_requested` | Internal notice when a member requests a refund. |
+| `refund_requested` | Sent to a member when they request a refund. |
 | `refund_processed` | Sent to attendees when a refund request is approved and issued. |
 | `event_sold_out` | Internal alert when an event reaches capacity. |
 | `waitlist_available` | Sent when a ticket becomes available for someone on the waitlist. |
@@ -37,7 +36,7 @@ Default values are provided on initial install:
 - **Purchase SMS**: "Thanks for registering! View your upcoming events at "
 - **24-Hour Reminder Email Body**: "Heads-up! Your event is just 1 day away! Below are the details."
 - **2-Hour Reminder Email Body**: "Your event is only 2 hours away! Below are the details."
-- **Admin Notifications**: emails are sent when new events are created, refunds are requested or events sell out.
+- **Admin Notifications**: internal alerts are sent when events sell out.
 - **Host and Volunteer Reminders**: internal messages mirror attendee reminders at 24 and 2 hours before the event.
 
 Links to the member dashboard now output the full site URL and include direct links to each dashboard tab, including the waitlist view.
@@ -152,7 +151,7 @@ The editor provides helper buttons beneath the token sections:
   the email is sent.
 - **Line Break** – inserts a newline. Email previews render these as HTML
   `<br>` tags so the saved text remains plain.
-- **bold** – wraps the highlighted text with `**` markers. The enclosed text
+- **Bold** – wraps the highlighted text with `**` markers. The enclosed text
   appears in bold in the final email.
 
 Template text can include Markdown-style links directly, so


### PR DESCRIPTION
## Summary
- handle escaped apostrophes in Email & SMS preview
- drop "New Event Created" template and mark "Refund Requested" as external
- capitalise "Bold" formatting button and document updated templates

## Testing
- `composer install`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689252a66938832092977def81873efd