### PR TITLE
Add tabbed interface for ads admin page

### DIFF
--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-ads-admin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-ads-admin.php
@@ -26,30 +26,23 @@ class TTA_Ads_Admin {
     }
 
     public function render_page() {
-        $ads = get_option( 'tta_ads', [] );
-        if ( isset( $_POST['tta_ads_nonce'] ) && wp_verify_nonce( $_POST['tta_ads_nonce'], 'tta_ads_save' ) ) {
-            $new_ads = [];
-            if ( isset( $_POST['ads'] ) && is_array( $_POST['ads'] ) ) {
-                foreach ( $_POST['ads'] as $ad ) {
-                    $id  = intval( $ad['image_id'] ?? 0 );
-                    $url = esc_url_raw( $ad['url'] ?? '' );
-                    if ( $id ) {
-                        $new_ads[] = [
-                            'image_id'        => $id,
-                            'url'             => $url,
-                            'business_name'   => sanitize_text_field( $ad['business_name'] ?? '' ),
-                            'business_phone'  => sanitize_text_field( $ad['business_phone'] ?? '' ),
-                            'business_address'=> sanitize_text_field( $ad['business_address'] ?? '' ),
-                        ];
-                    }
-                }
-            }
-            update_option( 'tta_ads', $new_ads, false );
-            TTA_Cache::delete( 'tta_ads_all' );
-            $ads = $new_ads;
-            echo '<div class="updated"><p>' . esc_html__( 'Ads saved.', 'tta' ) . '</p></div>';
+        $tabs    = [ 'create' => 'Create Ad', 'manage' => 'Manage Ads' ];
+        $current = isset( $_GET['tab'] ) && isset( $tabs[ $_GET['tab'] ] ) ? $_GET['tab'] : 'create';
+
+        echo '<h1>TTA Ads</h1><h2 class="nav-tab-wrapper">';
+        foreach ( $tabs as $slug => $label ) {
+            $class = $current === $slug ? ' nav-tab-active' : '';
+            $url   = esc_url( add_query_arg( [ 'page' => 'tta-ads', 'tab' => $slug ], admin_url( 'admin.php' ) ) );
+            printf( '<a href="%s" class="nav-tab%s">%s</a>', $url, $class, esc_html( $label ) );
         }
-        include TTA_PLUGIN_DIR . 'includes/admin/views/ads-manage.php';
+        echo '</h2>';
+
+        $view = TTA_PLUGIN_DIR . "includes/admin/views/ads-{$current}.php";
+        if ( file_exists( $view ) ) {
+            include $view;
+        } else {
+            echo '<div class="wrap"><p>' . esc_html__( 'View not found.', 'tta' ) . '</p></div>';
+        }
     }
 }
 

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/views/ads-create.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/views/ads-create.php
@@ -1,0 +1,81 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+$ads     = get_option( 'tta_ads', [] );
+$editing = false;
+$ad      = [];
+$index   = null;
+
+if ( isset( $_GET['ad_id'] ) && isset( $ads[ intval( $_GET['ad_id'] ) ] ) ) {
+    $index   = intval( $_GET['ad_id'] );
+    $ad      = $ads[ $index ];
+    $editing = true;
+}
+
+if ( isset( $_POST['tta_ad_save'] ) && check_admin_referer( 'tta_ad_save_action', 'tta_ad_save_nonce' ) ) {
+    $new_ad = [
+        'image_id'        => intval( $_POST['image_id'] ?? 0 ),
+        'url'             => esc_url_raw( $_POST['url'] ?? '' ),
+        'business_name'   => sanitize_text_field( $_POST['business_name'] ?? '' ),
+        'business_phone'  => sanitize_text_field( $_POST['business_phone'] ?? '' ),
+        'business_address'=> sanitize_text_field( $_POST['business_address'] ?? '' ),
+    ];
+
+    if ( $editing && null !== $index ) {
+        $ads[ $index ] = $new_ad;
+        echo '<div class="updated"><p>' . esc_html__( 'Ad updated.', 'tta' ) . '</p></div>';
+    } else {
+        $ads[] = $new_ad;
+        $index = array_key_last( $ads );
+        $editing = true;
+        echo '<div class="updated"><p>' . esc_html__( 'Ad created.', 'tta' ) . '</p></div>';
+    }
+
+    update_option( 'tta_ads', array_values( $ads ), false );
+    TTA_Cache::delete( 'tta_ads_all' );
+    $ad = $new_ad;
+}
+?>
+<div class="wrap">
+<form method="post">
+    <?php wp_nonce_field( 'tta_ad_save_action', 'tta_ad_save_nonce' ); ?>
+    <?php if ( $editing && null !== $index ) : ?>
+        <input type="hidden" name="ad_id" value="<?php echo esc_attr( $index ); ?>">
+    <?php endif; ?>
+    <table class="form-table">
+        <tbody>
+            <tr>
+                <th scope="row"><?php esc_html_e( 'Ad Image', 'tta' ); ?></th>
+                <td>
+                    <button class="button tta-upload-single" data-target="#ad_image"><?php esc_html_e( 'Select Image', 'tta' ); ?></button>
+                    <input type="hidden" id="ad_image" name="image_id" value="<?php echo esc_attr( $ad['image_id'] ?? 0 ); ?>">
+                    <div id="ad_image_preview"><?php echo ! empty( $ad['image_id'] ) ? wp_get_attachment_image( intval( $ad['image_id'] ), 'thumbnail' ) : ''; ?></div>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="url"><?php esc_html_e( 'Link URL', 'tta' ); ?></label></th>
+                <td><input type="url" name="url" id="url" class="regular-text" value="<?php echo esc_attr( $ad['url'] ?? '' ); ?>"></td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="business_name"><?php esc_html_e( 'Business Name', 'tta' ); ?></label></th>
+                <td><input type="text" name="business_name" id="business_name" class="regular-text" value="<?php echo esc_attr( $ad['business_name'] ?? '' ); ?>"></td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="business_phone"><?php esc_html_e( 'Business Telephone', 'tta' ); ?></label></th>
+                <td><input type="text" name="business_phone" id="business_phone" class="regular-text" value="<?php echo esc_attr( $ad['business_phone'] ?? '' ); ?>"></td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="business_address"><?php esc_html_e( 'Business Address', 'tta' ); ?></label></th>
+                <td><input type="text" name="business_address" id="business_address" class="regular-text" value="<?php echo esc_attr( $ad['business_address'] ?? '' ); ?>"></td>
+            </tr>
+        </tbody>
+    </table>
+    <p class="submit">
+        <button type="submit" name="tta_ad_save" class="button button-primary">
+            <?php echo $editing ? esc_html__( 'Update Ad', 'tta' ) : esc_html__( 'Create Ad', 'tta' ); ?>
+        </button>
+    </p>
+</form>
+</div>

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/views/ads-manage.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/views/ads-manage.php
@@ -2,79 +2,46 @@
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
-?>
-<div class="wrap">
-<h1><?php esc_html_e( 'Manage Ads', 'tta' ); ?></h1>
-<form method="post">
-<table class="form-table" id="tta-ads-table">
-<tbody>
-<?php
-if ( ! empty( $ads ) ) {
-    foreach ( $ads as $index => $ad ) {
-        $img_id = intval( $ad['image_id'] );
-        $url    = esc_url( $ad['url'] );
-        $name   = sanitize_text_field( $ad['business_name'] ?? '' );
-        $phone  = sanitize_text_field( $ad['business_phone'] ?? '' );
-        $address= sanitize_text_field( $ad['business_address'] ?? '' );
-        $preview = $img_id ? wp_get_attachment_image( $img_id, 'thumbnail' ) : '';
-        ?>
-        <tr class="tta-ad-row" data-index="<?php echo esc_attr( $index ); ?>">
-            <th scope="row"><?php esc_html_e( 'Ad Image', 'tta' ); ?></th>
-            <td>
-                <button class="button tta-upload-single" data-target="#ad_image_<?php echo esc_attr( $index ); ?>"><?php esc_html_e( 'Select Image', 'tta' ); ?></button>
-                <input type="hidden" id="ad_image_<?php echo esc_attr( $index ); ?>" name="ads[<?php echo esc_attr( $index ); ?>][image_id]" value="<?php echo esc_attr( $img_id ); ?>">
-                <div id="ad_image_preview_<?php echo esc_attr( $index ); ?>"><?php echo $preview; ?></div>
-            </td>
-        </tr>
-        <tr class="tta-ad-row" data-index="<?php echo esc_attr( $index ); ?>">
-            <th scope="row"><?php esc_html_e( 'Link URL', 'tta' ); ?></th>
-            <td>
-                <input type="text" name="ads[<?php echo esc_attr( $index ); ?>][url]" value="<?php echo esc_attr( $url ); ?>" class="regular-text" />
-                <button class="button tta-remove-ad">&times;</button>
-            </td>
-        </tr>
-        <tr class="tta-ad-row" data-index="<?php echo esc_attr( $index ); ?>">
-            <th scope="row"><?php esc_html_e( 'Business Name', 'tta' ); ?></th>
-            <td><input type="text" name="ads[<?php echo esc_attr( $index ); ?>][business_name]" value="<?php echo esc_attr( $name ); ?>" class="regular-text" /></td>
-        </tr>
-        <tr class="tta-ad-row" data-index="<?php echo esc_attr( $index ); ?>">
-            <th scope="row"><?php esc_html_e( 'Business Telephone', 'tta' ); ?></th>
-            <td><input type="text" name="ads[<?php echo esc_attr( $index ); ?>][business_phone]" value="<?php echo esc_attr( $phone ); ?>" class="regular-text" /></td>
-        </tr>
-        <tr class="tta-ad-row" data-index="<?php echo esc_attr( $index ); ?>">
-            <th scope="row"><?php esc_html_e( 'Business Address', 'tta' ); ?></th>
-            <td><input type="text" name="ads[<?php echo esc_attr( $index ); ?>][business_address]" value="<?php echo esc_attr( $address ); ?>" class="regular-text" /></td>
-        </tr>
-        <?php
+
+$ads = get_option( 'tta_ads', [] );
+
+if ( isset( $_GET['action'], $_GET['ad_id'] ) && 'delete' === $_GET['action'] && check_admin_referer( 'tta_ads_delete' ) ) {
+    $idx = intval( $_GET['ad_id'] );
+    if ( isset( $ads[ $idx ] ) ) {
+        unset( $ads[ $idx ] );
+        $ads = array_values( $ads );
+        update_option( 'tta_ads', $ads, false );
+        TTA_Cache::delete( 'tta_ads_all' );
+        echo '<div class="updated"><p>' . esc_html__( 'Ad deleted.', 'tta' ) . '</p></div>';
     }
 }
 ?>
-</tbody>
+<div class="wrap">
+<table class="widefat striped">
+    <thead>
+        <tr>
+            <th><?php esc_html_e( 'Image', 'tta' ); ?></th>
+            <th><?php esc_html_e( 'Business Name', 'tta' ); ?></th>
+            <th><?php esc_html_e( 'URL', 'tta' ); ?></th>
+            <th><?php esc_html_e( 'Actions', 'tta' ); ?></th>
+        </tr>
+    </thead>
+    <tbody>
+    <?php if ( ! empty( $ads ) ) : ?>
+        <?php foreach ( $ads as $i => $ad ) : ?>
+            <tr>
+                <td><?php echo ! empty( $ad['image_id'] ) ? wp_get_attachment_image( intval( $ad['image_id'] ), 'thumbnail' ) : ''; ?></td>
+                <td><?php echo esc_html( $ad['business_name'] ?? '' ); ?></td>
+                <td><?php echo esc_html( $ad['url'] ?? '' ); ?></td>
+                <td>
+                    <a href="<?php echo esc_url( add_query_arg( [ 'page' => 'tta-ads', 'tab' => 'create', 'ad_id' => $i ], admin_url( 'admin.php' ) ) ); ?>"><?php esc_html_e( 'Edit', 'tta' ); ?></a> |
+                    <a href="<?php echo esc_url( wp_nonce_url( add_query_arg( [ 'page' => 'tta-ads', 'tab' => 'manage', 'action' => 'delete', 'ad_id' => $i ], admin_url( 'admin.php' ) ), 'tta_ads_delete' ) ); ?>" onclick="return confirm('<?php esc_attr_e( 'Delete this ad?', 'tta' ); ?>');"><?php esc_html_e( 'Delete', 'tta' ); ?></a>
+                </td>
+            </tr>
+        <?php endforeach; ?>
+    <?php else : ?>
+        <tr><td colspan="4"><?php esc_html_e( 'No ads found.', 'tta' ); ?></td></tr>
+    <?php endif; ?>
+    </tbody>
 </table>
-<p>
-    <button type="button" class="button" id="tta-add-ad"><?php esc_html_e( 'Add Ad', 'tta' ); ?></button>
-</p>
-<?php wp_nonce_field( 'tta_ads_save', 'tta_ads_nonce' ); ?>
-<p class="submit"><input type="submit" class="button-primary" value="<?php esc_attr_e( 'Save Ads', 'tta' ); ?>"></p>
-</form>
 </div>
-<script>
-jQuery(function($){
-    var index = <?php echo isset( $index ) ? intval( $index + 1 ) : 0; ?>;
-    $('#tta-add-ad').on('click', function(e){
-        e.preventDefault();
-        var rowImg = '<tr class="tta-ad-row" data-index="'+index+'"><th scope="row"><?php esc_html_e( 'Ad Image', 'tta' ); ?></th><td><button class="button tta-upload-single" data-target="#ad_image_'+index+'">Select Image</button><input type="hidden" id="ad_image_'+index+'" name="ads['+index+'][image_id]" value=""><div id="ad_image_preview_'+index+'"></div></td></tr>';
-        var rowUrl = '<tr class="tta-ad-row" data-index="'+index+'"><th scope="row"><?php esc_html_e( 'Link URL', 'tta' ); ?></th><td><input type="text" name="ads['+index+'][url]" value="" class="regular-text" /> <button class="button tta-remove-ad">&times;</button></td></tr>';
-        var rowName = '<tr class="tta-ad-row" data-index="'+index+'"><th scope="row"><?php esc_html_e( 'Business Name', 'tta' ); ?></th><td><input type="text" name="ads['+index+'][business_name]" value="" class="regular-text" /></td></tr>';
-        var rowPhone = '<tr class="tta-ad-row" data-index="'+index+'"><th scope="row"><?php esc_html_e( 'Business Telephone', 'tta' ); ?></th><td><input type="text" name="ads['+index+'][business_phone]" value="" class="regular-text" /></td></tr>';
-        var rowAddress = '<tr class="tta-ad-row" data-index="'+index+'"><th scope="row"><?php esc_html_e( 'Business Address', 'tta' ); ?></th><td><input type="text" name="ads['+index+'][business_address]" value="" class="regular-text" /></td></tr>';
-        $('#tta-ads-table tbody').append(rowImg + rowUrl + rowName + rowPhone + rowAddress);
-        index++;
-    });
-    $('#tta-ads-table').on('click','.tta-remove-ad',function(e){
-        e.preventDefault();
-        var idx = $(this).closest('tr').data('index');
-        $('#tta-ads-table').find('tr[data-index="'+idx+'"]').remove();
-    });
-});
-</script>

--- a/docs/AdsAdmin.md
+++ b/docs/AdsAdmin.md
@@ -1,9 +1,8 @@
 # TTA Ads Admin Page
 
-The **TTA Ads** screen allows administrators to manage sidebar advertisements displayed on the Events List Page.
+The **TTA Ads** screen is split into two tabs:
 
-- Upload any number of ad images and provide an optional link URL for each.
-- On each page load, the Events List Page picks one ad at random to display in the right‑hand column.
-- Images are stored as WordPress attachments; only the attachment ID and URL are saved.
+1. **Create Ad** – Upload an image, enter the target URL and optional business details, then click **Create Ad**. Existing ads can be edited by choosing **Edit** from the **Manage Ads** tab. Images are stored as WordPress attachments; only the attachment ID and details are saved.
+2. **Manage Ads** – Lists all saved ads with their image preview, business name and URL. From here you can **Edit** or **Delete** ads. Deleting an ad immediately removes it from rotation.
 
-Use the **Add Ad** button to insert additional rows. Each row can be removed using the **×** button. Remember to click **Save Ads** when finished. Saved ads immediately clear the plugin cache so the random rotation reflects your changes right away.
+On each page load, the Events List Page picks one ad at random to display in the right‑hand column. Any changes automatically clear the plugin cache so the rotation reflects updates right away.


### PR DESCRIPTION
## Summary
- add tabbed navigation to Ads admin page with Create Ad and Manage Ads views
- implement dedicated forms for adding/editing ads and listing existing ads
- document new workflow in AdsAdmin.md

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6895007f6a348320bceb94c52d9fde91