### PR TITLE
Add homepage shortcode and assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ messages will not be sent.
 - [Authorize.Net Error Codes](docs/AuthorizeNetErrors.md)
 - [Address Helper Functions](docs/AddressHelpers.md)
 - [Event Page Context](docs/EventPage.md)
+- [Homepage Shortcode](docs/HomepageShortcode.md)
 - [Event Hosts & Volunteers](docs/EventPage.md#event-hosts-and-volunteers)
 - [Event Creation Admin](docs/EventCreationAdmin.md)
 - [Event Type Options](docs/EventTypes.md)

--- a/app/public/wp-content/plugins/tta-management-plugin/assets/css/frontend/event-page.css
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/css/frontend/event-page.css
@@ -16,20 +16,13 @@
   border-radius:4px;
 }
 
-.tta-events-ad__title{
-  margin-bottom: 0.5em;
-  font-size: 1.25em;
-  display: inline-block;
-  vertical-align: super;
-  border: solid 1px #eee;
-  border-left: 0;
-  border-right: 0;
-  border-top: 0;
+.tta-events-ad h2{
+  display:flex;
+  align-items:center;
+  gap:0.25rem;
   margin-top:0;
-}
-
-.tta-event-details-icon-special-size{
-  width:30px!important;
+  margin-bottom:0.5em;
+  font-size:1.25em;
 }
 
 #main > div > div > div > aside.tta-event-right > div > a{

--- a/app/public/wp-content/plugins/tta-management-plugin/assets/css/frontend/events-list.css
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/css/frontend/events-list.css
@@ -17,20 +17,13 @@
   border-radius:4px;
 }
 
-.tta-events-ad__title{
-  margin-bottom: 0.5em;
-  font-size: 1.25em;
-  display: inline-block;
-  vertical-align: super;
-  border: solid 1px #eee;
-  border-left: 0;
-  border-right: 0;
-  border-top: 0;
+.tta-events-ad h2{
+  display:flex;
+  align-items:center;
+  gap:0.25rem;
   margin-top:0;
-}
-
-.tta-event-details-icon-special-size{
-  width:30px!important;
+  margin-bottom:0.5em;
+  font-size:1.25em;
 }
 
 #main > div.wrap.tta-events-list-page > div > aside.tta-events-right > div > a{

--- a/app/public/wp-content/plugins/tta-management-plugin/assets/css/frontend/homepage-shortcode.css
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/css/frontend/homepage-shortcode.css
@@ -1,0 +1,78 @@
+/* Styles for the TTA homepage shortcode layout */
+.tta-home {
+    display: grid;
+    grid-template-columns: 300px 1fr;
+    gap: 2rem;
+}
+@media (max-width: 768px) {
+    .tta-home {
+        grid-template-columns: 1fr;
+    }
+}
+.tta-home-sidebar {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+.tta-home-main h2 {
+    margin-top: 0;
+}
+.tta-stats-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+.tta-stats-list li {
+    margin-bottom: 0.25rem;
+}
+.tta-counter {
+    font-size: 2rem;
+    font-weight: bold;
+}
+.tta-events-grid,
+.tta-past-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px,1fr));
+    gap: 1rem;
+}
+.tta-event-card {
+    position: relative;
+    padding-top: 56.25%; /* 16:9 */
+    background-size: cover;
+    background-position: center;
+    border-radius: 8px;
+}
+.tta-event-card__caption {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: rgba(0,0,0,0.6);
+    color: #fff;
+    padding: 0.5rem;
+    font-size: 0.9rem;
+}
+.tta-birthday-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, 60px);
+    gap: 0.5rem;
+}
+.tta-birthday-grid img {
+    width: 60px;
+    height: 60px;
+    border-radius: 50%;
+    object-fit: cover;
+}
+.tta-partners {
+    margin-top: 2rem;
+}
+.tta-home-main .tta-section {
+    margin-bottom: 3rem;
+}
+.tta-home-main .tta-section h2 {
+    margin-bottom: 1rem;
+}
+.tta-section-button {
+    text-align: center;
+    margin-top: 1rem;
+}

--- a/app/public/wp-content/plugins/tta-management-plugin/assets/css/frontend/homepage-shortcode.css
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/css/frontend/homepage-shortcode.css
@@ -14,6 +14,39 @@
     flex-direction: column;
     gap: 2rem;
 }
+.tta-intro-inner {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 2rem;
+    align-items: center;
+}
+@media (max-width: 768px) {
+    .tta-intro-inner {
+        grid-template-columns: 1fr;
+    }
+}
+.tta-intro-img {
+    position: relative;
+    overflow: hidden;
+    aspect-ratio: 16/9;
+}
+.tta-intro-img img {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    opacity: 0;
+    transition: opacity 1s ease, transform 1s ease;
+}
+.tta-intro-img img.active {
+    opacity: 1;
+}
+.tta-intro-img img.exit {
+    transform: translateX(100%);
+    opacity: 0;
+}
 .tta-home-main h2 {
     margin-top: 0;
 }
@@ -47,8 +80,8 @@
 }
 .tta-event-card {
     position: relative;
-    width: 75%;
-    aspect-ratio: 1/1;
+    width: 100%;
+    aspect-ratio: 16/9;
     background-size: cover;
     background-position: center;
     border-radius: 8px;
@@ -81,6 +114,9 @@
     border-radius: 50%;
     object-fit: cover;
 }
+.tta-popup-img {
+    cursor: pointer;
+}
 .tta-partners {
     margin-top: 2rem;
 }
@@ -103,6 +139,31 @@
     top: 2px;
     margin-right: 4px;
 }
+.tta-next-event__link {
+    display: block;
+    text-decoration: none;
+    color: inherit;
+}
+.tta-next-event__link p {
+    display: flex;
+    align-items: center;
+    margin: 0.25rem 0;
+}
+.tta-newest-member {
+    text-align: center;
+}
+.tta-newest-member__img {
+    width: 80px;
+    height: 80px;
+    border-radius: 50%;
+    object-fit: cover;
+    display: block;
+    margin: 0 auto 0.5rem;
+}
+.tta-newest-member__name,
+.tta-newest-member__level {
+    margin: 0;
+}
 
 .tta-events-ad {
     text-align: left;
@@ -110,19 +171,13 @@
 .tta-events-ad a img {
     border-radius: 4px;
 }
-.tta-events-ad__title {
+.tta-events-ad h2 {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    margin-top: 0;
     margin-bottom: 0.5em;
     font-size: 1.25em;
-    display: inline-block;
-    vertical-align: super;
-    border: solid 1px #eee;
-    border-left: 0;
-    border-right: 0;
-    border-top: 0;
-    margin-top: 0;
-}
-.tta-event-details-icon-special-size {
-    width: 30px !important;
 }
 .tta-events-ad__subtitle {
     margin-bottom: 1em;

--- a/app/public/wp-content/plugins/tta-management-plugin/assets/css/frontend/homepage-shortcode.css
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/css/frontend/homepage-shortcode.css
@@ -17,12 +17,21 @@
 .tta-home-main h2 {
     margin-top: 0;
 }
+.tta-home-sidebar h2 {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    margin-top: 0;
+}
+
 .tta-stats-list {
     list-style: none;
     margin: 0;
     padding: 0;
 }
 .tta-stats-list li {
+    display: flex;
+    align-items: center;
     margin-bottom: 0.25rem;
 }
 .tta-counter {
@@ -33,11 +42,12 @@
 .tta-past-grid {
     display: grid;
     grid-template-columns: repeat(2, 1fr);
-    grid-auto-rows: 1fr;
-    gap: 0.5rem;
+    justify-items: center;
+    gap: 1rem;
 }
 .tta-event-card {
     position: relative;
+    width: 75%;
     aspect-ratio: 1/1;
     background-size: cover;
     background-position: center;
@@ -50,8 +60,8 @@
     right: 0;
     background: rgba(0,0,0,0.6);
     color: #fff;
-    padding: 0.75rem;
-    font-size: 1.1rem;
+    padding: 1rem;
+    font-size: 1.3rem;
     text-align: center;
 }
 .tta-next-event__img {
@@ -83,4 +93,52 @@
 .tta-section-button {
     text-align: center;
     margin-top: 1rem;
+}
+
+.tta-event-details-icon {
+    width: 18px;
+    height: 18px;
+    flex: 0 0 auto;
+    position: relative;
+    top: 2px;
+    margin-right: 4px;
+}
+
+.tta-events-ad {
+    text-align: left;
+}
+.tta-events-ad a img {
+    border-radius: 4px;
+}
+.tta-events-ad__title {
+    margin-bottom: 0.5em;
+    font-size: 1.25em;
+    display: inline-block;
+    vertical-align: super;
+    border: solid 1px #eee;
+    border-left: 0;
+    border-right: 0;
+    border-top: 0;
+    margin-top: 0;
+}
+.tta-event-details-icon-special-size {
+    width: 30px !important;
+}
+.tta-events-ad__subtitle {
+    margin-bottom: 1em;
+    font-size: 1em;
+    text-align: left;
+}
+.tta-events-ad__info {
+    margin-top: 1em;
+}
+.tta-events-ad__info-item {
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    margin-bottom: 0.5em;
+}
+.tta-event-details-icon-after {
+    flex: 1 1 auto;
+    text-align: left;
 }

--- a/app/public/wp-content/plugins/tta-management-plugin/assets/css/frontend/homepage-shortcode.css
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/css/frontend/homepage-shortcode.css
@@ -2,7 +2,9 @@
 .tta-home {
     display: grid;
     grid-template-columns: 300px 1fr;
-    gap: 2rem;
+    gap: 3rem;
+    padding: 2rem;
+    margin: 2rem auto;
 }
 @media (max-width: 768px) {
     .tta-home {
@@ -18,7 +20,7 @@
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: 2rem;
-    align-items: center;
+    align-items: flex-start;
 }
 @media (max-width: 768px) {
     .tta-intro-inner {
@@ -66,10 +68,11 @@
     display: flex;
     align-items: center;
     margin-bottom: 0.25rem;
+    gap: 0.25rem;
 }
 .tta-counter {
-    font-size: 2rem;
-    font-weight: bold;
+    font-size: inherit;
+    font-weight: normal;
 }
 .tta-events-grid,
 .tta-past-grid {
@@ -125,6 +128,17 @@
 }
 .tta-home-main .tta-section h2 {
     margin-bottom: 1rem;
+    font-size: 2rem;
+}
+.tta-upcoming h2,
+.tta-past h2 {
+    text-align: center;
+}
+.tta-intro h1 {
+    font-size: 2.5rem;
+}
+.tta-intro p {
+    font-size: 1.125rem;
 }
 .tta-section-button {
     text-align: center;
@@ -177,7 +191,6 @@
     gap: 0.25rem;
     margin-top: 0;
     margin-bottom: 0.5em;
-    font-size: 1.25em;
 }
 .tta-events-ad__subtitle {
     margin-bottom: 1em;

--- a/app/public/wp-content/plugins/tta-management-plugin/assets/css/frontend/homepage-shortcode.css
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/css/frontend/homepage-shortcode.css
@@ -32,12 +32,13 @@
 .tta-events-grid,
 .tta-past-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(200px,1fr));
-    gap: 1rem;
+    grid-template-columns: repeat(2, 1fr);
+    grid-auto-rows: 1fr;
+    gap: 0.5rem;
 }
 .tta-event-card {
     position: relative;
-    padding-top: 56.25%; /* 16:9 */
+    aspect-ratio: 1/1;
     background-size: cover;
     background-position: center;
     border-radius: 8px;
@@ -49,8 +50,15 @@
     right: 0;
     background: rgba(0,0,0,0.6);
     color: #fff;
-    padding: 0.5rem;
-    font-size: 0.9rem;
+    padding: 0.75rem;
+    font-size: 1.1rem;
+    text-align: center;
+}
+.tta-next-event__img {
+    width: 100%;
+    height: auto;
+    border-radius: 8px;
+    display: block;
 }
 .tta-birthday-grid {
     display: grid;

--- a/app/public/wp-content/plugins/tta-management-plugin/assets/js/frontend/homepage-shortcode.js
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/js/frontend/homepage-shortcode.js
@@ -21,5 +21,23 @@
         $('.tta-counter').each(function(){
             animateCounter($(this));
         });
+
+        var $carousel = $('.tta-intro-img');
+        var $imgs = $carousel.find('img');
+        if ($imgs.length > 1) {
+            var idx = 0;
+            function cycle(){
+                var $current = $imgs.eq(idx);
+                idx = (idx + 1) % $imgs.length;
+                var $next = $imgs.eq(idx);
+                $current.removeClass('active').addClass('exit');
+                $next.addClass('active');
+                setTimeout(function(){
+                    $current.removeClass('exit');
+                }, 1000);
+                setTimeout(cycle, 5000);
+            }
+            setTimeout(cycle, 5000);
+        }
     });
 })(jQuery);

--- a/app/public/wp-content/plugins/tta-management-plugin/assets/js/frontend/homepage-shortcode.js
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/js/frontend/homepage-shortcode.js
@@ -1,0 +1,25 @@
+(function($){
+    function animateCounter($el){
+        var target = parseInt($el.data('target'),10);
+        var duration = 5000;
+        var startTime = null;
+        function step(timestamp){
+            if(!startTime){ startTime = timestamp; }
+            var progress = Math.min((timestamp - startTime)/duration,1);
+            var eased = 1 - Math.pow(1 - progress, 3); // ease out
+            var value = Math.floor(eased * target);
+            $el.text(value.toLocaleString());
+            if(progress < 1){
+                window.requestAnimationFrame(step);
+            } else {
+                $el.text(target.toLocaleString());
+            }
+        }
+        window.requestAnimationFrame(step);
+    }
+    $(function(){
+        $('.tta-counter').each(function(){
+            animateCounter($(this));
+        });
+    });
+})(jQuery);

--- a/app/public/wp-content/plugins/tta-management-plugin/assets/js/frontend/homepage-shortcode.js
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/js/frontend/homepage-shortcode.js
@@ -39,5 +39,22 @@
             }
             setTimeout(cycle, 5000);
         }
+
+        var $cd = $('.tta-countdown');
+        if ($cd.length) {
+            var target = parseInt($cd.data('time'), 10) * 1000;
+            function plural(v, s, p){ return v + ' ' + (v === 1 ? s : p); }
+            function update(){
+                var now = Date.now();
+                var diff = Math.max(0, target - now);
+                var days = Math.floor(diff / 86400000);
+                var hours = Math.floor((diff % 86400000) / 3600000);
+                var mins = Math.floor((diff % 3600000) / 60000);
+                var secs = Math.floor((diff % 60000) / 1000);
+                $cd.text(plural(days,'day','days') + ', ' + plural(hours,'hour','hours') + ', ' + plural(mins,'minute','minutes') + ', ' + plural(secs,'second','seconds'));
+            }
+            update();
+            setInterval(update, 1000);
+        }
     });
 })(jQuery);

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/classes/class-tta-assets.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/classes/class-tta-assets.php
@@ -160,6 +160,34 @@ class TTA_Assets {
             TTA_PLUGIN_VERSION
         );
 
+        // Register assets used by shortcodes.
+        wp_register_style(
+            'tta-homepage-shortcode',
+            TTA_PLUGIN_URL . 'assets/css/frontend/homepage-shortcode.css',
+            [ 'tta-frontend-css' ],
+            TTA_PLUGIN_VERSION
+        );
+        wp_register_script(
+            'tta-homepage-shortcode',
+            TTA_PLUGIN_URL . 'assets/js/frontend/homepage-shortcode.js',
+            [ 'jquery' ],
+            TTA_PLUGIN_VERSION,
+            true
+        );
+        wp_register_style(
+            'tta-popup-css',
+            TTA_PLUGIN_URL . 'assets/css/frontend/profile-popup.css',
+            [ 'tta-frontend-css' ],
+            TTA_PLUGIN_VERSION
+        );
+        wp_register_script(
+            'tta-popup-js',
+            TTA_PLUGIN_URL . 'assets/js/frontend/profile-popup.js',
+            [ 'jquery' ],
+            TTA_PLUGIN_VERSION,
+            true
+        );
+
 
         // 2) Only on our “Event Page” template, enqueue event-page.css and cart + event JS
         if ( function_exists( 'is_page_template' ) && is_page_template( 'event-page-template.php' ) ) {

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/templates/event-page-template.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/templates/event-page-template.php
@@ -1299,10 +1299,9 @@ echo '<div id="tta-login-wrap">' . $form_html . $lost_pw_html . '</div>';
     </aside>
 
     <aside class="tta-event-right">
-      <div class="tta-events-ad">
-        <h3 class="tta-events-ad__title"><?php esc_html_e( 'Meet Our Local Partners', 'tta' ); ?></h3>
-        <img class="tta-event-details-icon tta-event-details-icon-special-size" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/deal.svg' ); ?>" alt="<?php esc_attr_e( 'Local Trying To Adult Partners', 'tta' ); ?>">
-        <p class="tta-events-ad__subtitle"><?php esc_html_e( 'We\'re so grateful for local businesses that help make Trying to Adult possible. Check out our featured partner below!', 'tta' ); ?></p>
+    <div class="tta-events-ad">
+        <h2><img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/deal.svg' ); ?>" alt=""><?php esc_html_e( 'Meet Our Local Partners', 'tta' ); ?></h2>
+        <p class="tta-events-ad__subtitle"><?php esc_html_e( 'We\'re grateful for local partners & businesses that help make Trying to Adult possible. Check out our featured partner below!', 'tta' ); ?></p>
         <?php $ad = tta_get_random_ad(); ?>
         <?php if ( $ad ) : ?>
           <?php $img = wp_get_attachment_image( intval( $ad['image_id'] ), 'medium' ); ?>

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/templates/events-list-page-template.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/templates/events-list-page-template.php
@@ -407,9 +407,8 @@ $next_url = $next_allowed ? add_query_arg( [ 'cal_year' => $next_year, 'cal_mont
     </main>
     <aside class="tta-events-right">
         <div class="tta-events-ad">
-            <h3 class="tta-events-ad__title"><?php esc_html_e( 'Meet Our Local Partners', 'tta' ); ?></h3>
-            <img class="tta-event-details-icon tta-event-details-icon-special-size" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/deal.svg' ); ?>" alt="<?php esc_attr_e( 'Local Trying To Adult Partners', 'tta' ); ?>">
-            <p class="tta-events-ad__subtitle"><?php esc_html_e( 'We\'re so grateful for local businesses that help make Trying to Adult possible. Check out our featured partner below!', 'tta' ); ?></p>
+            <h2><img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/deal.svg' ); ?>" alt=""><?php esc_html_e( 'Meet Our Local Partners', 'tta' ); ?></h2>
+            <p class="tta-events-ad__subtitle"><?php esc_html_e( 'We\'re grateful for local partners & businesses that help make Trying to Adult possible. Check out our featured partner below!', 'tta' ); ?></p>
             <?php $ad = tta_get_random_ad(); ?>
             <?php if ( $ad ) : ?>
                 <?php $img = wp_get_attachment_image( intval( $ad['image_id'] ), 'medium' ); ?>

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
@@ -3436,6 +3436,12 @@ function tta_get_next_event() {
         'date_formatted'     => tta_format_event_date( $row['date'] ),
         'time_formatted'     => tta_format_event_time( $row['time'] ),
         'mainimageid'        => intval( $row['mainimageid'] ),
+        'timestamp'          => ( function() use ( $row ) {
+            $tz  = function_exists( 'wp_timezone' ) ? wp_timezone() : new DateTimeZone( 'UTC' );
+            $time = explode( '|', $row['time'] )[0];
+            $dt   = new DateTime( $row['date'] . ' ' . $time, $tz );
+            return $dt->getTimestamp();
+        } )(),
     ];
 
     $names = tta_get_event_host_volunteer_names( $event['id'] );

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
@@ -3409,7 +3409,7 @@ function tta_get_next_event() {
 
     $row = $wpdb->get_row(
         $wpdb->prepare(
-            "SELECT id, name, date, time, address, page_id, type, venuename, venueurl, baseeventcost, discountedmembercost, premiummembercost, hosts, volunteers, host_notes FROM {$events_table} WHERE date >= %s ORDER BY date ASC, time ASC LIMIT 1",
+            "SELECT id, name, date, time, address, page_id, type, venuename, venueurl, baseeventcost, discountedmembercost, premiummembercost, hosts, volunteers, host_notes, mainimageid FROM {$events_table} WHERE date >= %s ORDER BY date ASC, time ASC LIMIT 1",
             current_time( 'Y-m-d' )
         ),
         ARRAY_A
@@ -3435,6 +3435,7 @@ function tta_get_next_event() {
         'premium_cost'       => floatval( $row['premiummembercost'] ),
         'date_formatted'     => tta_format_event_date( $row['date'] ),
         'time_formatted'     => tta_format_event_time( $row['time'] ),
+        'mainimageid'        => intval( $row['mainimageid'] ),
     ];
 
     $names = tta_get_event_host_volunteer_names( $event['id'] );

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/shortcodes/class-homepage-shortcode.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/shortcodes/class-homepage-shortcode.php
@@ -1,0 +1,290 @@
+<?php
+/**
+ * Shortcode to render the Trying to Adult RVA homepage layout.
+ *
+ * Outputs a two column layout with sidebar and main content areas populated
+ * with dynamic data such as upcoming events and members.
+ *
+ * Usage: [tta_homepage]
+ *
+ * @package TTA\Shortcodes
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Register the `[tta_homepage]` shortcode.
+ */
+class TTA_Homepage_Shortcode {
+
+    /**
+     * Get singleton instance.
+     *
+     * @return self
+     */
+    public static function get_instance() {
+        static $inst = null;
+        if ( null === $inst ) {
+            $inst = new self();
+        }
+        return $inst;
+    }
+
+    /**
+     * Hook into WordPress.
+     */
+    private function __construct() {
+        add_shortcode( 'tta_homepage', [ $this, 'render' ] );
+    }
+
+    /**
+     * Render the shortcode output.
+     *
+     * @param array $atts Shortcode attributes.
+     *
+     * @return string
+     */
+    public function render( $atts = [] ) {
+        wp_enqueue_style( 'tta-homepage-shortcode' );
+        wp_enqueue_script( 'tta-homepage-shortcode' );
+        wp_enqueue_style( 'tta-popup-css' );
+        wp_enqueue_script( 'tta-popup-js' );
+
+        $next_event    = tta_get_next_event();
+        $upcoming      = tta_get_upcoming_events( 1, 4 );
+        $past_events   = $this->get_recent_past_events( 2 );
+        $newest_member = $this->get_newest_member();
+        $birthdays     = $this->get_birthdays_this_month();
+        $member_count  = $this->get_member_count();
+        $event_count   = $this->get_event_count();
+        $current_month = date_i18n( 'F' );
+
+        ob_start();
+        ?>
+        <div class="tta-home">
+            <aside class="tta-home-sidebar">
+                <div class="tta-stats">
+                    <h2><?php esc_html_e( 'TTA Stats', 'tta' ); ?></h2>
+                    <ul class="tta-stats-list">
+                        <li><?php esc_html_e( 'Founded in 2020', 'tta' ); ?></li>
+                        <li><span class="tta-counter" aria-live="polite" data-target="<?php echo esc_attr( $member_count ); ?>">0</span> <?php esc_html_e( 'Members', 'tta' ); ?></li>
+                        <li><span class="tta-counter" aria-live="polite" data-target="<?php echo esc_attr( $event_count ); ?>">0</span> <?php esc_html_e( 'Events', 'tta' ); ?></li>
+                    </ul>
+                </div>
+                <?php if ( $next_event ) : ?>
+                    <div class="tta-next-event">
+                        <h2><?php esc_html_e( 'Our Next Event', 'tta' ); ?></h2>
+                        <?php if ( ! empty( $next_event['mainimageid'] ) ) : ?>
+                            <?php $img = wp_get_attachment_image_url( intval( $next_event['mainimageid'] ), 'medium' ); ?>
+                            <?php if ( $img ) : ?><div class="tta-next-event__img" style="background-image:url('<?php echo esc_url( $img ); ?>');"></div><?php endif; ?>
+                        <?php endif; ?>
+                        <p><?php echo esc_html( $next_event['name'] ); ?><br><?php echo esc_html( $next_event['date_formatted'] ); ?></p>
+                        <p><a class="button" href="<?php echo esc_url( get_permalink( $next_event['page_id'] ) ); ?>"><?php esc_html_e( 'Learn More', 'tta' ); ?></a></p>
+                    </div>
+                <?php endif; ?>
+                <?php if ( $newest_member ) : ?>
+                    <div class="tta-newest-member">
+                        <h2><?php esc_html_e( 'Our Newest Member', 'tta' ); ?></h2>
+                        <?php
+                        $img_id  = intval( $newest_member['profileimgid'] );
+                        $img_url = $img_id ? wp_get_attachment_image_url( $img_id, 'thumbnail' ) : TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/placeholder-profile.svg';
+                        ?>
+                        <a href="#" class="tta-profile-popup" data-member="<?php echo esc_attr( $newest_member['id'] ); ?>">
+                            <img class="tta-newest-member__img" src="<?php echo esc_url( $img_url ); ?>" alt="">
+                        </a>
+                        <p><?php echo esc_html( $newest_member['first_name'] . ' ' . $newest_member['last_name'] ); ?></p>
+                        <p><?php echo esc_html( ucfirst( $newest_member['membership_level'] ) ); ?></p>
+                    </div>
+                <?php endif; ?>
+                <?php if ( ! empty( $birthdays ) ) : ?>
+                    <div class="tta-birthdays">
+                        <h2><?php echo esc_html( $current_month . ' ' . __( 'Birthdays', 'tta' ) ); ?></h2>
+                        <div class="tta-birthday-grid">
+                            <?php foreach ( $birthdays as $b ) :
+                                $img_id  = intval( $b['profileimgid'] );
+                                $img_url = $img_id ? wp_get_attachment_image_url( $img_id, 'thumbnail' ) : TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/placeholder-profile.svg';
+                                ?>
+                                <a href="#" class="tta-profile-popup" data-member="<?php echo esc_attr( $b['id'] ); ?>"><img src="<?php echo esc_url( $img_url ); ?>" alt=""></a>
+                            <?php endforeach; ?>
+                        </div>
+                        <div class="tta-section-button"><button type="button" class="tta-birthday-toggle button"><?php esc_html_e( 'All Birthdays', 'tta' ); ?></button></div>
+                    </div>
+                <?php endif; ?>
+                <div class="tta-partners">
+                    <h2><?php esc_html_e( 'Our Partners', 'tta' ); ?></h2>
+                    <?php $ad = tta_get_random_ad(); ?>
+                    <?php if ( $ad ) : ?>
+                        <?php $img = wp_get_attachment_image( intval( $ad['image_id'] ), 'medium' ); ?>
+                        <?php if ( $ad['url'] ) : ?><a href="<?php echo esc_url( $ad['url'] ); ?>" target="_blank" rel="noopener"><?php endif; ?>
+                        <?php echo $img ? $img : '<img src="' . esc_url( TTA_PLUGIN_URL . 'assets/images/ads/placeholder1.svg' ) . '" alt="">'; ?>
+                        <?php if ( $ad['url'] ) : ?></a><?php endif; ?>
+                        <div class="tta-events-ad__info">
+                            <?php if ( ! empty( $ad['business_name'] ) ) : ?>
+                                <div class="tta-events-ad__info-item"><?php echo esc_html( $ad['business_name'] ); ?></div>
+                            <?php endif; ?>
+                            <?php if ( ! empty( $ad['business_phone'] ) ) : ?>
+                                <?php $tel = preg_replace( '/[^0-9+]/', '', $ad['business_phone'] ); ?>
+                                <div class="tta-events-ad__info-item"><a href="tel:<?php echo esc_attr( $tel ); ?>"><?php echo esc_html( $ad['business_phone'] ); ?></a></div>
+                            <?php endif; ?>
+                            <?php if ( ! empty( $ad['business_address'] ) ) : ?>
+                                <?php $map = 'https://www.google.com/maps/search/?api=1&query=' . urlencode( $ad['business_address'] ); ?>
+                                <div class="tta-events-ad__info-item"><a href="<?php echo esc_url( $map ); ?>" target="_blank" rel="noopener"><?php echo esc_html( $ad['business_address'] ); ?></a></div>
+                            <?php endif; ?>
+                        </div>
+                    <?php else : ?>
+                        <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/ads/placeholder1.svg' ); ?>" alt="">
+                    <?php endif; ?>
+                </div>
+            </aside>
+            <div class="tta-home-main">
+                <section class="tta-section tta-intro">
+                    <div class="tta-intro-inner">
+                        <div>
+                            <h1><?php esc_html_e( 'What is Trying to Adult RVA?', 'tta' ); ?></h1>
+                            <p><?php esc_html_e( 'Trying to Adult RVA is a community focused on connection and growth.', 'tta' ); ?></p>
+                            <p><a class="button" href="<?php echo esc_url( home_url( '/events' ) ); ?>"><?php esc_html_e( 'Browse Events', 'tta' ); ?></a></p>
+                        </div>
+                        <div class="tta-intro-img"></div>
+                    </div>
+                </section>
+                <?php if ( ! empty( $upcoming['events'] ) ) : ?>
+                    <section class="tta-section tta-upcoming">
+                        <h2><?php esc_html_e( 'Upcoming Events', 'tta' ); ?></h2>
+                        <div class="tta-events-grid">
+                            <?php foreach ( $upcoming['events'] as $event ) :
+                                $img = $event['mainimageid'] ? wp_get_attachment_image_url( intval( $event['mainimageid'] ), 'medium' ) : TTA_PLUGIN_URL . 'assets/images/admin/default-event.png';
+                                ?>
+                                <a href="<?php echo esc_url( get_permalink( $event['page_id'] ) ); ?>" class="tta-event-card" style="background-image:url('<?php echo esc_url( $img ); ?>');">
+                                    <div class="tta-event-card__caption"><?php echo esc_html( $event['name'] ); ?><br><?php echo esc_html( tta_format_event_date( $event['date'] ) ); ?></div>
+                                </a>
+                            <?php endforeach; ?>
+                        </div>
+                        <div class="tta-section-button"><a class="button" href="<?php echo esc_url( home_url( '/events' ) ); ?>"><?php esc_html_e( 'All Upcoming Events', 'tta' ); ?></a></div>
+                    </section>
+                <?php endif; ?>
+                <?php if ( ! empty( $past_events ) ) : ?>
+                    <section class="tta-section tta-past">
+                        <h2><?php esc_html_e( 'Past Events', 'tta' ); ?></h2>
+                        <div class="tta-past-grid">
+                            <?php foreach ( $past_events as $event ) :
+                                $img = $event['mainimageid'] ? wp_get_attachment_image_url( intval( $event['mainimageid'] ), 'medium' ) : TTA_PLUGIN_URL . 'assets/images/admin/default-event.png';
+                                ?>
+                                <a href="<?php echo esc_url( get_permalink( $event['page_id'] ) ); ?>" class="tta-event-card" style="background-image:url('<?php echo esc_url( $img ); ?>');">
+                                    <div class="tta-event-card__caption"><?php echo esc_html( $event['name'] ); ?><br><?php echo esc_html( tta_format_event_date( $event['date'] ) ); ?></div>
+                                </a>
+                            <?php endforeach; ?>
+                        </div>
+                        <div class="tta-section-button"><a class="button" href="<?php echo esc_url( home_url( '/past-events' ) ); ?>"><?php esc_html_e( 'More Past Events', 'tta' ); ?></a></div>
+                    </section>
+                <?php endif; ?>
+            </div>
+        </div>
+        <?php
+        return ob_get_clean();
+    }
+
+    /**
+     * Retrieve most recent past events.
+     *
+     * @param int $limit Number of events.
+     *
+     * @return array[]
+     */
+    private function get_recent_past_events( $limit = 2 ) {
+        return TTA_Cache::remember( 'recent_past_events_' . $limit, function() use ( $limit ) {
+            global $wpdb;
+            $events_table = $wpdb->prefix . 'tta_events';
+            $sql = $wpdb->prepare(
+                "SELECT id, name, date, page_id, mainimageid FROM {$events_table} WHERE date < %s ORDER BY date DESC LIMIT %d",
+                current_time( 'Y-m-d' ),
+                $limit
+            );
+            $rows = $wpdb->get_results( $sql, ARRAY_A );
+            foreach ( $rows as &$row ) {
+                $row['id']          = intval( $row['id'] );
+                $row['page_id']     = intval( $row['page_id'] );
+                $row['mainimageid'] = intval( $row['mainimageid'] );
+                $row['name']        = sanitize_text_field( $row['name'] );
+            }
+            return $rows;
+        }, 300 );
+    }
+
+    /**
+     * Retrieve the most recently joined member.
+     *
+     * @return array|null
+     */
+    private function get_newest_member() {
+        return TTA_Cache::remember( 'tta_newest_member', function() {
+            global $wpdb;
+            $members_table = $wpdb->prefix . 'tta_members';
+            $row = $wpdb->get_row( "SELECT id, first_name, last_name, membership_level, profileimgid FROM {$members_table} ORDER BY joined_at DESC LIMIT 1", ARRAY_A );
+            if ( ! $row ) {
+                return null;
+            }
+            return [
+                'id'              => intval( $row['id'] ),
+                'first_name'      => sanitize_text_field( $row['first_name'] ),
+                'last_name'       => sanitize_text_field( $row['last_name'] ),
+                'membership_level'=> sanitize_text_field( $row['membership_level'] ),
+                'profileimgid'    => intval( $row['profileimgid'] ),
+            ];
+        }, 300 );
+    }
+
+    /**
+     * Retrieve members with birthdays in the current month.
+     *
+     * @return array[]
+     */
+    private function get_birthdays_this_month() {
+        return TTA_Cache::remember( 'tta_birthdays_' . date( 'm' ), function() {
+            global $wpdb;
+            $members_table = $wpdb->prefix . 'tta_members';
+            $month = date_i18n( 'm' );
+            $rows = $wpdb->get_results( $wpdb->prepare( "SELECT id, profileimgid FROM {$members_table} WHERE MONTH(dob) = %d", $month ), ARRAY_A );
+            $members = [];
+            foreach ( $rows as $row ) {
+                $members[] = [
+                    'id'          => intval( $row['id'] ),
+                    'profileimgid'=> intval( $row['profileimgid'] ),
+                ];
+            }
+            return $members;
+        }, 300 );
+    }
+
+    /**
+     * Get total number of members.
+     *
+     * @return int
+     */
+    private function get_member_count() {
+        return TTA_Cache::remember( 'tta_member_count', function() {
+            global $wpdb;
+            $table = $wpdb->prefix . 'tta_members';
+            return (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$table}" );
+        }, 600 );
+    }
+
+    /**
+     * Get total number of events (current and archived).
+     *
+     * @return int
+     */
+    private function get_event_count() {
+        return TTA_Cache::remember( 'tta_event_count', function() {
+            global $wpdb;
+            $current = $wpdb->prefix . 'tta_events';
+            $archive = $wpdb->prefix . 'tta_events_archive';
+            $count1  = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$current}" );
+            $count2  = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$archive}" );
+            return $count1 + $count2;
+        }, 600 );
+    }
+}
+
+TTA_Homepage_Shortcode::get_instance();

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/shortcodes/class-homepage-shortcode.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/shortcodes/class-homepage-shortcode.php
@@ -54,7 +54,7 @@ class TTA_Homepage_Shortcode {
 
         $next_event    = tta_get_next_event();
         $upcoming      = tta_get_upcoming_events( 1, 4 );
-        $past_events   = $this->get_recent_past_events( 2 );
+        $past_events   = $this->get_recent_past_events( 4 );
         $newest_member = $this->get_newest_member();
         $birthdays     = $this->get_birthdays_this_month();
         $member_count  = $this->get_member_count();
@@ -77,10 +77,11 @@ class TTA_Homepage_Shortcode {
                     <div class="tta-next-event">
                         <h2><?php esc_html_e( 'Our Next Event', 'tta' ); ?></h2>
                         <?php if ( ! empty( $next_event['mainimageid'] ) ) : ?>
-                            <?php $img = wp_get_attachment_image_url( intval( $next_event['mainimageid'] ), 'medium' ); ?>
-                            <?php if ( $img ) : ?><div class="tta-next-event__img" style="background-image:url('<?php echo esc_url( $img ); ?>');"></div><?php endif; ?>
+                            <?php $img = wp_get_attachment_image_url( intval( $next_event['mainimageid'] ), 'large' ); ?>
+                            <?php if ( $img ) : ?><img class="tta-next-event__img" src="<?php echo esc_url( $img ); ?>" alt=""><?php endif; ?>
                         <?php endif; ?>
-                        <p><?php echo esc_html( $next_event['name'] ); ?><br><?php echo esc_html( $next_event['date_formatted'] ); ?></p>
+                        <p class="tta-next-event__name"><?php echo esc_html( $next_event['name'] ); ?></p>
+                        <p class="tta-next-event__date"><?php echo esc_html( $next_event['date_formatted'] ); ?></p>
                         <p><a class="button" href="<?php echo esc_url( get_permalink( $next_event['page_id'] ) ); ?>"><?php esc_html_e( 'Learn More', 'tta' ); ?></a></p>
                     </div>
                 <?php endif; ?>
@@ -263,11 +264,7 @@ class TTA_Homepage_Shortcode {
      * @return int
      */
     private function get_member_count() {
-        return TTA_Cache::remember( 'tta_member_count', function() {
-            global $wpdb;
-            $table = $wpdb->prefix . 'tta_members';
-            return (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$table}" );
-        }, 600 );
+        return 5382;
     }
 
     /**
@@ -276,14 +273,7 @@ class TTA_Homepage_Shortcode {
      * @return int
      */
     private function get_event_count() {
-        return TTA_Cache::remember( 'tta_event_count', function() {
-            global $wpdb;
-            $current = $wpdb->prefix . 'tta_events';
-            $archive = $wpdb->prefix . 'tta_events_archive';
-            $count1  = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$current}" );
-            $count2  = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$archive}" );
-            return $count1 + $count2;
-        }, 600 );
+        return 1032;
     }
 }
 

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/shortcodes/class-homepage-shortcode.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/shortcodes/class-homepage-shortcode.php
@@ -69,17 +69,15 @@ class TTA_Homepage_Shortcode {
                     <h2><?php esc_html_e( 'TTA Stats', 'tta' ); ?></h2>
                     <ul class="tta-stats-list">
                         <li><?php esc_html_e( 'Founded in 2020', 'tta' ); ?></li>
-                        <li><span class="tta-counter" aria-live="polite" data-target="<?php echo esc_attr( $member_count ); ?>">0</span> <?php esc_html_e( 'Members', 'tta' ); ?></li>
-                        <li><span class="tta-counter" aria-live="polite" data-target="<?php echo esc_attr( $event_count ); ?>">0</span> <?php esc_html_e( 'Events', 'tta' ); ?></li>
+                        <li><img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/profile.svg' ); ?>" alt="<?php esc_attr_e( 'Members', 'tta' ); ?>"><span class="tta-counter" aria-live="polite" data-target="<?php echo esc_attr( $member_count ); ?>">0</span> <?php esc_html_e( 'Members', 'tta' ); ?></li>
+                        <li><img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/calendar.svg' ); ?>" alt="<?php esc_attr_e( 'Events', 'tta' ); ?>"><span class="tta-counter" aria-live="polite" data-target="<?php echo esc_attr( $event_count ); ?>">0</span> <?php esc_html_e( 'Events', 'tta' ); ?></li>
                     </ul>
                 </div>
                 <?php if ( $next_event ) : ?>
                     <div class="tta-next-event">
-                        <h2><?php esc_html_e( 'Our Next Event', 'tta' ); ?></h2>
-                        <?php if ( ! empty( $next_event['mainimageid'] ) ) : ?>
-                            <?php $img = wp_get_attachment_image_url( intval( $next_event['mainimageid'] ), 'large' ); ?>
-                            <?php if ( $img ) : ?><img class="tta-next-event__img" src="<?php echo esc_url( $img ); ?>" alt=""><?php endif; ?>
-                        <?php endif; ?>
+                        <h2><img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/upcoming.svg' ); ?>" alt=""><?php esc_html_e( 'Our Next Event', 'tta' ); ?></h2>
+                        <?php $img = $next_event['mainimageid'] ? wp_get_attachment_image_url( intval( $next_event['mainimageid'] ), 'large' ) : TTA_PLUGIN_URL . 'assets/images/admin/default-event.png'; ?>
+                        <?php if ( $img ) : ?><img class="tta-next-event__img" src="<?php echo esc_url( $img ); ?>" alt="<?php echo esc_attr( $next_event['name'] ); ?>"><?php endif; ?>
                         <p class="tta-next-event__name"><?php echo esc_html( $next_event['name'] ); ?></p>
                         <p class="tta-next-event__date"><?php echo esc_html( $next_event['date_formatted'] ); ?></p>
                         <p><a class="button" href="<?php echo esc_url( get_permalink( $next_event['page_id'] ) ); ?>"><?php esc_html_e( 'Learn More', 'tta' ); ?></a></p>
@@ -87,7 +85,7 @@ class TTA_Homepage_Shortcode {
                 <?php endif; ?>
                 <?php if ( $newest_member ) : ?>
                     <div class="tta-newest-member">
-                        <h2><?php esc_html_e( 'Our Newest Member', 'tta' ); ?></h2>
+                        <h2><img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/profile.svg' ); ?>" alt=""><?php esc_html_e( 'Our Newest Member', 'tta' ); ?></h2>
                         <?php
                         $img_id  = intval( $newest_member['profileimgid'] );
                         $img_url = $img_id ? wp_get_attachment_image_url( $img_id, 'thumbnail' ) : TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/placeholder-profile.svg';
@@ -101,7 +99,7 @@ class TTA_Homepage_Shortcode {
                 <?php endif; ?>
                 <?php if ( ! empty( $birthdays ) ) : ?>
                     <div class="tta-birthdays">
-                        <h2><?php echo esc_html( $current_month . ' ' . __( 'Birthdays', 'tta' ) ); ?></h2>
+                        <h2><img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/calendar.svg' ); ?>" alt=""><?php echo esc_html( $current_month . ' ' . __( 'Birthdays', 'tta' ) ); ?></h2>
                         <div class="tta-birthday-grid">
                             <?php foreach ( $birthdays as $b ) :
                                 $img_id  = intval( $b['profileimgid'] );
@@ -114,29 +112,48 @@ class TTA_Homepage_Shortcode {
                     </div>
                 <?php endif; ?>
                 <div class="tta-partners">
-                    <h2><?php esc_html_e( 'Our Partners', 'tta' ); ?></h2>
-                    <?php $ad = tta_get_random_ad(); ?>
-                    <?php if ( $ad ) : ?>
-                        <?php $img = wp_get_attachment_image( intval( $ad['image_id'] ), 'medium' ); ?>
-                        <?php if ( $ad['url'] ) : ?><a href="<?php echo esc_url( $ad['url'] ); ?>" target="_blank" rel="noopener"><?php endif; ?>
-                        <?php echo $img ? $img : '<img src="' . esc_url( TTA_PLUGIN_URL . 'assets/images/ads/placeholder1.svg' ) . '" alt="">'; ?>
-                        <?php if ( $ad['url'] ) : ?></a><?php endif; ?>
-                        <div class="tta-events-ad__info">
-                            <?php if ( ! empty( $ad['business_name'] ) ) : ?>
-                                <div class="tta-events-ad__info-item"><?php echo esc_html( $ad['business_name'] ); ?></div>
-                            <?php endif; ?>
-                            <?php if ( ! empty( $ad['business_phone'] ) ) : ?>
-                                <?php $tel = preg_replace( '/[^0-9+]/', '', $ad['business_phone'] ); ?>
-                                <div class="tta-events-ad__info-item"><a href="tel:<?php echo esc_attr( $tel ); ?>"><?php echo esc_html( $ad['business_phone'] ); ?></a></div>
-                            <?php endif; ?>
-                            <?php if ( ! empty( $ad['business_address'] ) ) : ?>
-                                <?php $map = 'https://www.google.com/maps/search/?api=1&query=' . urlencode( $ad['business_address'] ); ?>
-                                <div class="tta-events-ad__info-item"><a href="<?php echo esc_url( $map ); ?>" target="_blank" rel="noopener"><?php echo esc_html( $ad['business_address'] ); ?></a></div>
+                    <div class="tta-events-ad">
+                        <h3 class="tta-events-ad__title"><?php esc_html_e( 'Meet Our Local Partners', 'tta' ); ?></h3>
+        <img class="tta-event-details-icon tta-event-details-icon-special-size" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/deal.svg' ); ?>" alt="<?php esc_attr_e( 'Local Trying To Adult Partners', 'tta' ); ?>">
+        <p class="tta-events-ad__subtitle"><?php esc_html_e( 'We\'re so grateful for local businesses that help make Trying to Adult possible. Check out our featured partner below!', 'tta' ); ?></p>
+        <?php $ad = tta_get_random_ad(); ?>
+        <?php if ( $ad ) : ?>
+            <?php $img = wp_get_attachment_image( intval( $ad['image_id'] ), 'medium' ); ?>
+            <?php if ( $ad['url'] ) : ?><a href="<?php echo esc_url( $ad['url'] ); ?>" target="_blank" rel="noopener"><?php endif; ?>
+            <?php echo $img ? $img : '<img src="' . esc_url( TTA_PLUGIN_URL . 'assets/images/ads/placeholder1.svg' ) . '" alt="">'; ?>
+            <?php if ( $ad['url'] ) : ?></a><?php endif; ?>
+            <div class="tta-events-ad__info">
+                <?php if ( ! empty( $ad['business_name'] ) ) : ?>
+                    <div class="tta-events-ad__info-item">
+                        <img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/store.svg' ); ?>" alt="<?php esc_attr_e( 'Business', 'tta' ); ?>">
+                        <div class="tta-event-details-icon-after">
+                            <?php if ( ! empty( $ad['url'] ) ) : ?>
+                                <a href="<?php echo esc_url( $ad['url'] ); ?>" target="_blank" rel="noopener"><?php echo esc_html( $ad['business_name'] ); ?></a>
+                            <?php else : ?>
+                                <?php echo esc_html( $ad['business_name'] ); ?>
                             <?php endif; ?>
                         </div>
-                    <?php else : ?>
-                        <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/ads/placeholder1.svg' ); ?>" alt="">
-                    <?php endif; ?>
+                    </div>
+                <?php endif; ?>
+                <?php if ( ! empty( $ad['business_phone'] ) ) : ?>
+                    <?php $tel = preg_replace( '/[^0-9+]/', '', $ad['business_phone'] ); ?>
+                    <div class="tta-events-ad__info-item">
+                        <img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/phone-outline.svg' ); ?>" alt="<?php esc_attr_e( 'Phone', 'tta' ); ?>">
+                        <div class="tta-event-details-icon-after"><a href="tel:<?php echo esc_attr( $tel ); ?>"><?php echo esc_html( $ad['business_phone'] ); ?></a></div>
+                    </div>
+                <?php endif; ?>
+                <?php if ( ! empty( $ad['business_address'] ) ) : ?>
+                    <?php $map = 'https://www.google.com/maps/search/?api=1&query=' . urlencode( $ad['business_address'] ); ?>
+                    <div class="tta-events-ad__info-item">
+                        <img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/location.svg' ); ?>" alt="<?php esc_attr_e( 'Address', 'tta' ); ?>">
+                        <div class="tta-event-details-icon-after"><a href="<?php echo esc_url( $map ); ?>" target="_blank" rel="noopener"><?php echo esc_html( $ad['business_address'] ); ?></a></div>
+                    </div>
+                <?php endif; ?>
+            </div>
+        <?php else : ?>
+            <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/ads/placeholder1.svg' ); ?>" alt="">
+        <?php endif; ?>
+                    </div>
                 </div>
             </aside>
             <div class="tta-home-main">

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/shortcodes/class-homepage-shortcode.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/shortcodes/class-homepage-shortcode.php
@@ -66,7 +66,7 @@ class TTA_Homepage_Shortcode {
         <div class="tta-home">
             <aside class="tta-home-sidebar">
                 <div class="tta-stats">
-                    <h2><?php esc_html_e( 'TTA Stats', 'tta' ); ?></h2>
+                    <h2><img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/memberlevel.svg' ); ?>" alt=""><?php esc_html_e( 'TTA Stats', 'tta' ); ?></h2>
                     <ul class="tta-stats-list">
                         <li><?php esc_html_e( 'Founded in 2020', 'tta' ); ?></li>
                         <li><img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/profile.svg' ); ?>" alt="<?php esc_attr_e( 'Members', 'tta' ); ?>"><span class="tta-counter" aria-live="polite" data-target="<?php echo esc_attr( $member_count ); ?>">0</span> <?php esc_html_e( 'Members', 'tta' ); ?></li>
@@ -74,27 +74,29 @@ class TTA_Homepage_Shortcode {
                     </ul>
                 </div>
                 <?php if ( $next_event ) : ?>
+                    <?php $img = $next_event['mainimageid'] ? wp_get_attachment_image_url( intval( $next_event['mainimageid'] ), 'large' ) : TTA_PLUGIN_URL . 'assets/images/admin/default-event.png'; ?>
                     <div class="tta-next-event">
                         <h2><img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/upcoming.svg' ); ?>" alt=""><?php esc_html_e( 'Our Next Event', 'tta' ); ?></h2>
-                        <?php $img = $next_event['mainimageid'] ? wp_get_attachment_image_url( intval( $next_event['mainimageid'] ), 'large' ) : TTA_PLUGIN_URL . 'assets/images/admin/default-event.png'; ?>
-                        <?php if ( $img ) : ?><img class="tta-next-event__img" src="<?php echo esc_url( $img ); ?>" alt="<?php echo esc_attr( $next_event['name'] ); ?>"><?php endif; ?>
-                        <p class="tta-next-event__name"><?php echo esc_html( $next_event['name'] ); ?></p>
-                        <p class="tta-next-event__date"><?php echo esc_html( $next_event['date_formatted'] ); ?></p>
-                        <p><a class="button" href="<?php echo esc_url( get_permalink( $next_event['page_id'] ) ); ?>"><?php esc_html_e( 'Learn More', 'tta' ); ?></a></p>
+                        <a class="tta-next-event__link" href="<?php echo esc_url( get_permalink( $next_event['page_id'] ) ); ?>">
+                            <?php if ( $img ) : ?><img class="tta-next-event__img" src="<?php echo esc_url( $img ); ?>" alt="<?php echo esc_attr( $next_event['name'] ); ?>"><?php endif; ?>
+                            <p class="tta-next-event__name"><img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/profile.svg' ); ?>" alt=""><?php echo esc_html( $next_event['name'] ); ?></p>
+                            <p class="tta-next-event__date"><img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/calendar.svg' ); ?>" alt=""><?php echo esc_html( $next_event['date_formatted'] ); ?></p>
+                            <p class="tta-next-event__time"><img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/clock.svg' ); ?>" alt=""><?php echo esc_html( $next_event['time_formatted'] ); ?></p>
+                            <p class="tta-next-event__address"><img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/location.svg' ); ?>" alt=""><?php echo esc_html( $next_event['address'] ); ?></p>
+                        </a>
                     </div>
                 <?php endif; ?>
                 <?php if ( $newest_member ) : ?>
                     <div class="tta-newest-member">
                         <h2><img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/profile.svg' ); ?>" alt=""><?php esc_html_e( 'Our Newest Member', 'tta' ); ?></h2>
                         <?php
-                        $img_id  = intval( $newest_member['profileimgid'] );
-                        $img_url = $img_id ? wp_get_attachment_image_url( $img_id, 'thumbnail' ) : TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/placeholder-profile.svg';
+                        $img_id   = intval( $newest_member['profileimgid'] );
+                        $img_thumb = $img_id ? wp_get_attachment_image_url( $img_id, 'thumbnail' ) : TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/placeholder-profile.svg';
+                        $img_full  = $img_id ? wp_get_attachment_image_url( $img_id, 'full' ) : $img_thumb;
                         ?>
-                        <a href="#" class="tta-profile-popup" data-member="<?php echo esc_attr( $newest_member['id'] ); ?>">
-                            <img class="tta-newest-member__img" src="<?php echo esc_url( $img_url ); ?>" alt="">
-                        </a>
-                        <p><?php echo esc_html( $newest_member['first_name'] . ' ' . $newest_member['last_name'] ); ?></p>
-                        <p><?php echo esc_html( ucfirst( $newest_member['membership_level'] ) ); ?></p>
+                        <img class="tta-newest-member__img tta-popup-img" src="<?php echo esc_url( $img_thumb ); ?>" data-full="<?php echo esc_url( $img_full ); ?>" alt="<?php echo esc_attr( $newest_member['first_name'] . ' ' . $newest_member['last_name'] ); ?>">
+                        <p class="tta-newest-member__name"><?php echo esc_html( $newest_member['first_name'] . ' ' . $newest_member['last_name'] ); ?></p>
+                        <p class="tta-newest-member__level"><?php echo esc_html( ucfirst( $newest_member['membership_level'] ) ); ?></p>
                     </div>
                 <?php endif; ?>
                 <?php if ( ! empty( $birthdays ) ) : ?>
@@ -103,9 +105,10 @@ class TTA_Homepage_Shortcode {
                         <div class="tta-birthday-grid">
                             <?php foreach ( $birthdays as $b ) :
                                 $img_id  = intval( $b['profileimgid'] );
-                                $img_url = $img_id ? wp_get_attachment_image_url( $img_id, 'thumbnail' ) : TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/placeholder-profile.svg';
+                                $thumb   = $img_id ? wp_get_attachment_image_url( $img_id, 'thumbnail' ) : TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/placeholder-profile.svg';
+                                $full    = $img_id ? wp_get_attachment_image_url( $img_id, 'full' ) : $thumb;
                                 ?>
-                                <a href="#" class="tta-profile-popup" data-member="<?php echo esc_attr( $b['id'] ); ?>"><img src="<?php echo esc_url( $img_url ); ?>" alt=""></a>
+                                <img class="tta-popup-img" src="<?php echo esc_url( $thumb ); ?>" data-full="<?php echo esc_url( $full ); ?>" alt="">
                             <?php endforeach; ?>
                         </div>
                         <div class="tta-section-button"><button type="button" class="tta-birthday-toggle button"><?php esc_html_e( 'All Birthdays', 'tta' ); ?></button></div>
@@ -113,9 +116,8 @@ class TTA_Homepage_Shortcode {
                 <?php endif; ?>
                 <div class="tta-partners">
                     <div class="tta-events-ad">
-                        <h3 class="tta-events-ad__title"><?php esc_html_e( 'Meet Our Local Partners', 'tta' ); ?></h3>
-        <img class="tta-event-details-icon tta-event-details-icon-special-size" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/deal.svg' ); ?>" alt="<?php esc_attr_e( 'Local Trying To Adult Partners', 'tta' ); ?>">
-        <p class="tta-events-ad__subtitle"><?php esc_html_e( 'We\'re so grateful for local businesses that help make Trying to Adult possible. Check out our featured partner below!', 'tta' ); ?></p>
+                        <h2><img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/deal.svg' ); ?>" alt=""><?php esc_html_e( 'Meet Our Local Partners', 'tta' ); ?></h2>
+        <p class="tta-events-ad__subtitle"><?php esc_html_e( 'We\'re grateful for local partners & businesses that help make Trying to Adult possible. Check out our featured partner below!', 'tta' ); ?></p>
         <?php $ad = tta_get_random_ad(); ?>
         <?php if ( $ad ) : ?>
             <?php $img = wp_get_attachment_image( intval( $ad['image_id'] ), 'medium' ); ?>
@@ -161,10 +163,26 @@ class TTA_Homepage_Shortcode {
                     <div class="tta-intro-inner">
                         <div>
                             <h1><?php esc_html_e( 'What is Trying to Adult RVA?', 'tta' ); ?></h1>
-                            <p><?php esc_html_e( 'Trying to Adult RVA is a community focused on connection and growth.', 'tta' ); ?></p>
+                            <p><?php esc_html_e( 'Trying to Adult RVA is a Richmond community for adults looking to connect, grow and explore the city together.', 'tta' ); ?></p>
+                            <p><?php esc_html_e( 'Through game nights, workshops, service projects and casual meetups we create welcoming spaces to learn new skills, give back and build lasting friendships.', 'tta' ); ?></p>
                             <p><a class="button" href="<?php echo esc_url( home_url( '/events' ) ); ?>"><?php esc_html_e( 'Browse Events', 'tta' ); ?></a></p>
                         </div>
-                        <div class="tta-intro-img"></div>
+                        <div class="tta-intro-img">
+                            <?php
+                            $carousel_images = [
+                                '/wp-content/uploads/2022/12/IMG-1351.jpg',
+                                '/wp-content/uploads/2022/12/IMG-4850.jpg',
+                                '/wp-content/uploads/2022/12/IMG-1153.jpg',
+                                '/wp-content/uploads/2025/06/unnamed-6.webp',
+                                '/wp-content/uploads/2022/12/41657B74-F47D-451A-A99A-0B95C793FFD4-1.jpg',
+                                '/wp-content/uploads/2022/12/IMG-7075-1.jpg',
+                            ];
+                            foreach ( $carousel_images as $i => $src ) :
+                                $class = 0 === $i ? ' class="active"' : '';
+                                echo '<img src="' . esc_url( $src ) . '" alt=""' . $class . '>';
+                            endforeach;
+                            ?>
+                        </div>
                     </div>
                 </section>
                 <?php if ( ! empty( $upcoming['events'] ) ) : ?>

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/shortcodes/class-homepage-shortcode.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/shortcodes/class-homepage-shortcode.php
@@ -68,7 +68,7 @@ class TTA_Homepage_Shortcode {
                 <div class="tta-stats">
                     <h2><img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/memberlevel.svg' ); ?>" alt=""><?php esc_html_e( 'TTA Stats', 'tta' ); ?></h2>
                     <ul class="tta-stats-list">
-                        <li><?php esc_html_e( 'Founded in 2020', 'tta' ); ?></li>
+                        <li><img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/clock.svg' ); ?>" alt=""><span><?php esc_html_e( 'Founded in 2020', 'tta' ); ?></span></li>
                         <li><img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/profile.svg' ); ?>" alt="<?php esc_attr_e( 'Members', 'tta' ); ?>"><span class="tta-counter" aria-live="polite" data-target="<?php echo esc_attr( $member_count ); ?>">0</span> <?php esc_html_e( 'Members', 'tta' ); ?></li>
                         <li><img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/calendar.svg' ); ?>" alt="<?php esc_attr_e( 'Events', 'tta' ); ?>"><span class="tta-counter" aria-live="polite" data-target="<?php echo esc_attr( $event_count ); ?>">0</span> <?php esc_html_e( 'Events', 'tta' ); ?></li>
                     </ul>
@@ -79,6 +79,7 @@ class TTA_Homepage_Shortcode {
                         <h2><img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/upcoming.svg' ); ?>" alt=""><?php esc_html_e( 'Our Next Event', 'tta' ); ?></h2>
                         <a class="tta-next-event__link" href="<?php echo esc_url( get_permalink( $next_event['page_id'] ) ); ?>">
                             <?php if ( $img ) : ?><img class="tta-next-event__img" src="<?php echo esc_url( $img ); ?>" alt="<?php echo esc_attr( $next_event['name'] ); ?>"><?php endif; ?>
+                            <p class="tta-next-event__countdown"><img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/clock.svg' ); ?>" alt=""><span class="tta-countdown" data-time="<?php echo esc_attr( $next_event['timestamp'] ); ?>"></span></p>
                             <p class="tta-next-event__name"><img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/profile.svg' ); ?>" alt=""><?php echo esc_html( $next_event['name'] ); ?></p>
                             <p class="tta-next-event__date"><img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/calendar.svg' ); ?>" alt=""><?php echo esc_html( $next_event['date_formatted'] ); ?></p>
                             <p class="tta-next-event__time"><img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/clock.svg' ); ?>" alt=""><?php echo esc_html( $next_event['time_formatted'] ); ?></p>
@@ -164,7 +165,8 @@ class TTA_Homepage_Shortcode {
                         <div>
                             <h1><?php esc_html_e( 'What is Trying to Adult RVA?', 'tta' ); ?></h1>
                             <p><?php esc_html_e( 'Trying to Adult RVA is a Richmond community for adults looking to connect, grow and explore the city together.', 'tta' ); ?></p>
-                            <p><?php esc_html_e( 'Through game nights, workshops, service projects and casual meetups we create welcoming spaces to learn new skills, give back and build lasting friendships.', 'tta' ); ?></p>
+                            <p><?php esc_html_e( 'From potluck dinners and trivia nights to hikes and volunteer projects, we host a mix of events that make it easy to meet people and try something new.', 'tta' ); ?></p>
+                            <p><?php esc_html_e( 'Our mission is to create welcoming spaces to build life skills, give back and discover the best of RVA with friends who are figuring it out too. Whether you\'re new in town or a lifelong local, there\'s a seat for you at the table.', 'tta' ); ?></p>
                             <p><a class="button" href="<?php echo esc_url( home_url( '/events' ) ); ?>"><?php esc_html_e( 'Browse Events', 'tta' ); ?></a></p>
                         </div>
                         <div class="tta-intro-img">

--- a/app/public/wp-content/plugins/tta-management-plugin/trying-to-adult-management-plugin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/trying-to-adult-management-plugin.php
@@ -134,6 +134,7 @@ require_once TTA_PLUGIN_DIR . 'includes/admin/class-bi-admin.php';
 require_once TTA_PLUGIN_DIR . 'includes/admin/class-refund-requests-admin.php';
 require_once TTA_PLUGIN_DIR . 'includes/shortcodes/class-events-shortcode.php';
 require_once TTA_PLUGIN_DIR . 'includes/shortcodes/class-members-shortcode.php';
+require_once TTA_PLUGIN_DIR . 'includes/shortcodes/class-homepage-shortcode.php';
 require_once TTA_PLUGIN_DIR . 'includes/frontend/class-tta-member-dashboard.php';
 require_once TTA_PLUGIN_DIR . 'includes/frontend/class-tta-checkin-page-manager.php';
 require_once TTA_PLUGIN_DIR . 'includes/frontend/class-become-member-page.php';

--- a/docs/HomepageShortcode.md
+++ b/docs/HomepageShortcode.md
@@ -1,0 +1,16 @@
+# Homepage Shortcode
+
+The `[tta_homepage]` shortcode renders the Trying to Adult RVA homepage layout. It includes:
+
+- A sidebar with site stats, the next upcoming event, newest member information, current month birthdays and partner ads.
+- A main content area with an introduction, a grid of upcoming events, and a grid of recent past events.
+
+## Usage
+
+Add the shortcode to any page:
+
+```
+[tta_homepage]
+```
+
+Required assets are enqueued automatically.

--- a/docs/HomepageShortcode.md
+++ b/docs/HomepageShortcode.md
@@ -19,4 +19,5 @@ Required assets are enqueued automatically.
 
 - The members and events counters animate from 0 to **5,382** members and **1,032** events.
 - "Our Next Event" displays the event’s featured image followed by its name and date.
-- Event grids use large square cards arranged in two columns by two rows.
+- Event grids use square cards arranged in two columns by two rows.
+- The partner section mirrors the ad component used on event pages, including icons and contact details.

--- a/docs/HomepageShortcode.md
+++ b/docs/HomepageShortcode.md
@@ -3,7 +3,7 @@
 The `[tta_homepage]` shortcode renders the Trying to Adult RVA homepage layout. It includes:
 
 - A sidebar with site stats, the next upcoming event, newest member information, current month birthdays and partner ads.
-- A main content area with an introduction, a grid of upcoming events, and a grid of recent past events.
+- A main content area with an introduction, a 2×2 grid of upcoming events, and a 2×2 grid of recent past events.
 
 ## Usage
 
@@ -14,3 +14,9 @@ Add the shortcode to any page:
 ```
 
 Required assets are enqueued automatically.
+
+## Notes
+
+- The members and events counters animate from 0 to **5,382** members and **1,032** events.
+- "Our Next Event" displays the event’s featured image followed by its name and date.
+- Event grids use large square cards arranged in two columns by two rows.

--- a/docs/HomepageShortcode.md
+++ b/docs/HomepageShortcode.md
@@ -18,7 +18,7 @@ Required assets are enqueued automatically.
 ## Notes
 
 - The members and events counters animate from 0 to **5,382** members and **1,032** events.
-- "Our Next Event" links to the event and shows its image, name, date, time and address with icons.
+- "Our Next Event" links to the event, shows its image, name, date, time, address and a real-time countdown with icons.
 - Event grids use landscape cards arranged in two columns by two rows.
 - The intro image area cycles through several community photos.
 - The partner section mirrors the ad component used on event pages, including icons and contact details.

--- a/docs/HomepageShortcode.md
+++ b/docs/HomepageShortcode.md
@@ -3,7 +3,7 @@
 The `[tta_homepage]` shortcode renders the Trying to Adult RVA homepage layout. It includes:
 
 - A sidebar with site stats, the next upcoming event, newest member information, current month birthdays and partner ads.
-- A main content area with an introduction, a 2×2 grid of upcoming events, and a 2×2 grid of recent past events.
+- A main content area with an introduction carousel, a 2×2 grid of upcoming events, and a 2×2 grid of recent past events.
 
 ## Usage
 
@@ -18,6 +18,7 @@ Required assets are enqueued automatically.
 ## Notes
 
 - The members and events counters animate from 0 to **5,382** members and **1,032** events.
-- "Our Next Event" displays the event’s featured image followed by its name and date.
-- Event grids use square cards arranged in two columns by two rows.
+- "Our Next Event" links to the event and shows its image, name, date, time and address with icons.
+- Event grids use landscape cards arranged in two columns by two rows.
+- The intro image area cycles through several community photos.
 - The partner section mirrors the ad component used on event pages, including icons and contact details.


### PR DESCRIPTION
## Summary
- add `[tta_homepage]` shortcode that renders stats, upcoming events, and member highlights
- register/enqueue CSS and JS assets for homepage layout and counters
- document usage in new `HomepageShortcode` guide and reference in README

## Testing
- `composer install`
- `composer install -d app/public/wp-content/plugins/tta-management-plugin`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689635371f24832093287bda5e936e75