### PR TITLE
Add mobile accordion layout for member dashboard

### DIFF
--- a/app/public/wp-content/plugins/tta-management-plugin/assets/css/frontend/member-dashboard.css
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/css/frontend/member-dashboard.css
@@ -344,3 +344,37 @@
   margin-top: 10px;
 }
 
+/* Responsive mobile layout */
+@media (max-width: 1199px) {
+  .tta-member-dashboard {
+    flex-direction: column;
+  }
+  .tta-dashboard-sidebar {
+    display: none;
+  }
+  .tta-dashboard-content {
+    padding: 0;
+    border: none;
+  }
+  .tta-accordion-tab {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 15px;
+    margin-bottom: 10px;
+    background: #f9f9f9;
+    border: 1px solid #ddd;
+    cursor: pointer;
+  }
+  .tta-accordion-tab.active {
+    background: #eaeaea;
+    font-weight: bold;
+  }
+  .tta-dashboard-section {
+    display: none;
+    padding: 20px;
+    border: 1px solid #ddd;
+    border-top: none;
+    box-sizing: border-box;
+  }
+}
+

--- a/app/public/wp-content/plugins/tta-management-plugin/assets/css/frontend/style.css
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/css/frontend/style.css
@@ -94,9 +94,25 @@
   border-top:0;
 }
 
+.tta-event-cell img{
+  display:block;
+  margin:0 auto;
+}
+.tta-event-name{
+  margin-top:6px;
+  text-align:center;
+  font-weight:600;
+}
+
 .tta-info-title{
+  display:none;
   font-weight:600;
   margin-right:4px;
+}
+
+.tta-toggle-cell .tta-inline-container{
+  display:none;
+  margin-top:10px;
 }
 
 @media (max-width: 1199px){
@@ -132,4 +148,6 @@
   .tta-toggle-arrow{display:block;margin:4px auto 0;}
   .tta-checkin-wrap tr.tta-inline-row{border:none;padding:0;}
   .tta-checkin-wrap tr.tta-inline-row td{padding:0;}
+  .tta-info-title{display:inline;}
+  .tta-toggle-cell.open .tta-inline-container{display:block;}
 }

--- a/app/public/wp-content/plugins/tta-management-plugin/assets/css/frontend/style.css
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/css/frontend/style.css
@@ -11,6 +11,16 @@
   transform: rotate(180deg);
 }
 
+.tta-toggle-cell{
+  text-align:center;
+  cursor:pointer;
+}
+
+.tta-toggle-text{
+  display:none;
+  font-weight:700;
+}
+
 /* Become a Member page */
 .tta-become-member-wrap {
   max-width: 800px;
@@ -76,6 +86,19 @@
   margin-bottom:0px;
 }
 
+.tta-event-row.open{
+  border-bottom:0;
+}
+
+.tta-event-row.open + .tta-inline-row td{
+  border-top:0;
+}
+
+.tta-info-title{
+  font-weight:600;
+  margin-right:4px;
+}
+
 @media (max-width: 1199px){
   .tta-checkin-wrap table,
   .tta-checkin-wrap thead,
@@ -102,9 +125,11 @@
     margin-bottom:4px;
   }
   .tta-checkin-wrap td.tta-toggle-cell{
-    text-align:right;
+    text-align:center;
   }
   .tta-checkin-wrap td.tta-toggle-cell::before{content:'';}
+  .tta-toggle-text{display:block;}
+  .tta-toggle-arrow{display:block;margin:4px auto 0;}
   .tta-checkin-wrap tr.tta-inline-row{border:none;padding:0;}
   .tta-checkin-wrap tr.tta-inline-row td{padding:0;}
 }

--- a/app/public/wp-content/plugins/tta-management-plugin/assets/css/frontend/style.css
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/css/frontend/style.css
@@ -75,3 +75,36 @@
 .tta-checkin-wrap .tta-attendance-details h4{
   margin-bottom:0px;
 }
+
+@media (max-width: 1199px){
+  .tta-checkin-wrap table,
+  .tta-checkin-wrap thead,
+  .tta-checkin-wrap tbody,
+  .tta-checkin-wrap th,
+  .tta-checkin-wrap td,
+  .tta-checkin-wrap tr{
+    display:block;
+  }
+  .tta-checkin-wrap thead{display:none;}
+  .tta-checkin-wrap tr{
+    border:1px solid #ddd;
+    margin-bottom:15px;
+    padding:10px;
+  }
+  .tta-checkin-wrap td{
+    padding:8px 10px;
+    position:relative;
+  }
+  .tta-checkin-wrap td[data-label]::before{
+    content:attr(data-label);
+    font-weight:600;
+    display:block;
+    margin-bottom:4px;
+  }
+  .tta-checkin-wrap td.tta-toggle-cell{
+    text-align:right;
+  }
+  .tta-checkin-wrap td.tta-toggle-cell::before{content:'';}
+  .tta-checkin-wrap tr.tta-inline-row{border:none;padding:0;}
+  .tta-checkin-wrap tr.tta-inline-row td{padding:0;}
+}

--- a/app/public/wp-content/plugins/tta-management-plugin/assets/js/frontend/event-checkin.js
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/js/frontend/event-checkin.js
@@ -2,10 +2,35 @@ jQuery(function($){
   // Toggle event rows
   $(document).on('click', '.tta-event-row', function(e){
     if ($(e.target).is('button, a')) return;
-    var $row   = $(this),
-        $arrow = $row.find('.tta-toggle-arrow'),
-        ute    = $row.data('event-ute-id'),
-        $ex    = $row.next('.tta-inline-row');
+    var $row       = $(this),
+        $arrow     = $row.find('.tta-toggle-arrow'),
+        ute        = $row.data('event-ute-id'),
+        isMobile   = window.matchMedia('(max-width:1199px)').matches,
+        $toggleCell= $row.find('.tta-toggle-cell'),
+        $container = $toggleCell.find('.tta-inline-container'),
+        $ex        = $row.next('.tta-inline-row');
+
+    if (isMobile){
+      if ($toggleCell.hasClass('open')){
+        $arrow.removeClass('open');
+        $row.removeClass('open');
+        $toggleCell.removeClass('open');
+        $container.slideUp().empty();
+        return;
+      }
+      $('.tta-toggle-cell.open').removeClass('open').find('.tta-inline-container').slideUp().empty();
+      $('.tta-inline-row').remove();
+      $('.tta-toggle-arrow').removeClass('open');
+      $('.tta-event-row').removeClass('open');
+      $.post(TTA_Checkin.ajax_url, { action:'tta_get_event_attendance', nonce:TTA_Checkin.get_nonce, event_ute_id: ute }, function(res){
+        if(!res.success) return;
+        $container.html(res.data.html).slideDown();
+        $arrow.addClass('open');
+        $row.addClass('open');
+        $toggleCell.addClass('open');
+      }, 'json');
+      return;
+    }
 
     if ($ex.length){
       $arrow.removeClass('open');
@@ -17,6 +42,7 @@ jQuery(function($){
     $('.tta-inline-row').remove();
     $('.tta-toggle-arrow').removeClass('open');
     $('.tta-event-row').removeClass('open');
+    $('.tta-toggle-cell.open').removeClass('open').find('.tta-inline-container').empty().hide();
 
     $.post(TTA_Checkin.ajax_url, { action:'tta_get_event_attendance', nonce:TTA_Checkin.get_nonce, event_ute_id: ute }, function(res){
       if(!res.success) return;

--- a/app/public/wp-content/plugins/tta-management-plugin/assets/js/frontend/event-checkin.js
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/js/frontend/event-checkin.js
@@ -9,12 +9,14 @@ jQuery(function($){
 
     if ($ex.length){
       $arrow.removeClass('open');
+      $row.removeClass('open');
       $ex.remove();
       return;
     }
 
     $('.tta-inline-row').remove();
     $('.tta-toggle-arrow').removeClass('open');
+    $('.tta-event-row').removeClass('open');
 
     $.post(TTA_Checkin.ajax_url, { action:'tta_get_event_attendance', nonce:TTA_Checkin.get_nonce, event_ute_id: ute }, function(res){
       if(!res.success) return;
@@ -22,6 +24,7 @@ jQuery(function($){
       var $new = $('<tr class="tta-inline-row"><td colspan="'+colspan+'">'+res.data.html+'</td></tr>');
       $row.after($new);
       $arrow.addClass('open');
+      $row.addClass('open');
     }, 'json');
   });
 

--- a/app/public/wp-content/plugins/tta-management-plugin/assets/js/frontend/event-checkin.js
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/js/frontend/event-checkin.js
@@ -35,20 +35,22 @@ jQuery(function($){
     if ($ex.length){
       $arrow.removeClass('open');
       $row.removeClass('open');
-      $ex.remove();
+      $ex.find('.tta-inline-wrapper').slideUp(200, function(){ $ex.remove(); });
       return;
     }
 
-    $('.tta-inline-row').remove();
-    $('.tta-toggle-arrow').removeClass('open');
-    $('.tta-event-row').removeClass('open');
-    $('.tta-toggle-cell.open').removeClass('open').find('.tta-inline-container').empty().hide();
+    var $open = $('.tta-inline-row');
+    if ($open.length){
+      $open.prev('.tta-event-row').removeClass('open').find('.tta-toggle-arrow').removeClass('open');
+      $open.find('.tta-inline-wrapper').slideUp(200, function(){ $open.remove(); });
+    }
 
     $.post(TTA_Checkin.ajax_url, { action:'tta_get_event_attendance', nonce:TTA_Checkin.get_nonce, event_ute_id: ute }, function(res){
       if(!res.success) return;
       var colspan = $row.find('td').length;
-      var $new = $('<tr class="tta-inline-row"><td colspan="'+colspan+'">'+res.data.html+'</td></tr>');
+      var $new = $('<tr class="tta-inline-row"><td colspan="'+colspan+'"><div class="tta-inline-wrapper" style="display:none">'+res.data.html+'</div></td></tr>');
       $row.after($new);
+      $new.find('.tta-inline-wrapper').slideDown(200);
       $arrow.addClass('open');
       $row.addClass('open');
     }, 'json');

--- a/app/public/wp-content/plugins/tta-management-plugin/assets/js/frontend/member-dashboard.js
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/js/frontend/member-dashboard.js
@@ -26,18 +26,66 @@ jQuery(function($){
     $('#tab-' + tab).show();
   });
 
+  // Mobile accordion for narrow screens
+  function initAccordion(){
+    if (window.innerWidth >= 1200 || $('.tta-accordion-tab').length) return;
+    $('.tta-dashboard-tabs li').each(function(){
+      var tab = $(this).data('tab');
+      var label = $(this).text();
+      var $section = $('#tab-' + tab);
+      var $acc = $('<div>', { class: 'tta-accordion-tab', 'data-tab': tab }).text(label);
+      $section.before($acc);
+    });
+    $('.tta-dashboard-section').hide();
+    var current = $('.tta-dashboard-tabs li.active').data('tab') || 'profile';
+    $('.tta-accordion-tab[data-tab="' + current + '"]').addClass('active').next('.tta-dashboard-section').show();
+    $('.tta-accordion-tab').on('click', function(){
+      var tab = $(this).data('tab');
+      if ($(this).hasClass('active')) {
+        $(this).removeClass('active');
+        $('#tab-' + tab).slideUp(200);
+      } else {
+        $('.tta-accordion-tab').removeClass('active');
+        $('.tta-dashboard-section').slideUp(200);
+        $(this).addClass('active');
+        $('#tab-' + tab).slideDown(200);
+      }
+    });
+  }
+  function destroyAccordion(){
+    var current = $('.tta-accordion-tab.active').data('tab') || 'profile';
+    $('.tta-accordion-tab').remove();
+    $('.tta-dashboard-section').hide();
+    $('#tab-' + current).show();
+    $('.tta-dashboard-tabs li').removeClass('active').filter('[data-tab="' + current + '"]').addClass('active');
+  }
+  initAccordion();
+  $(window).on('resize', function(){
+    if (window.innerWidth < 1200) {
+      initAccordion();
+    } else if ($('.tta-accordion-tab').length) {
+      destroyAccordion();
+    }
+  });
+
   // Activate tab based on URL hash or ?tab=name parameter
   function activateTab(tab){
-    var $trigger = $('.tta-dashboard-tabs li[data-tab="' + tab + '"]');
-    if ($trigger.length) {
-      $trigger.trigger('click');
-      // scroll to the dashboard area after activating
-      var $wrap = $('.tta-member-dashboard-wrap');
-      var h = $('.site-header, .tta-header').first().outerHeight() || 0;
-      $('html, body').animate({
-        scrollTop: $wrap.offset().top - h - 100
-      }, 600);
+    if ($('.tta-accordion-tab').length) {
+      var $acc = $('.tta-accordion-tab[data-tab="' + tab + '"]');
+      if ($acc.length) {
+        $acc.trigger('click');
+      }
+    } else {
+      var $trigger = $('.tta-dashboard-tabs li[data-tab="' + tab + '"]');
+      if ($trigger.length) {
+        $trigger.trigger('click');
+      }
     }
+    var $wrap = $('.tta-member-dashboard-wrap');
+    var h = $('.site-header, .tta-header').first().outerHeight() || 0;
+    $('html, body').animate({
+      scrollTop: $wrap.offset().top - h - 100
+    }, 600);
   }
 
   var urlParams = new URLSearchParams(window.location.search);

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/templates/host-checkin-template.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/templates/host-checkin-template.php
@@ -58,12 +58,12 @@ echo do_shortcode( $header_shortcode );
         }
   ?>
     <tr class="tta-event-row" data-event-ute-id="<?php echo esc_attr( $e['ute_id'] ); ?>">
-      <td><?php echo $img; ?></td>
-      <td><?php echo esc_html( $e['name'] ); ?></td>
-      <td><?php echo esc_html( tta_format_event_datetime( $e['date'], $e['time'] ) ); ?></td>
-      <td><?php echo intval( tta_get_expected_attendee_count( $e['ute_id'] ) ); ?></td>
-      <td><?php echo esc_html( $status ); ?></td>
-      <td class="tta-toggle-cell"><img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/arrow.svg' ); ?>" class="tta-toggle-arrow" width="10" height="10" alt="Toggle"></td>
+      <td data-label="<?php echo esc_attr__( 'Event Image', 'tta' ); ?>"><?php echo $img; ?></td>
+      <td data-label="<?php echo esc_attr__( 'Event Name', 'tta' ); ?>"><?php echo esc_html( $e['name'] ); ?></td>
+      <td data-label="<?php echo esc_attr__( 'Date & Time', 'tta' ); ?>"><?php echo esc_html( tta_format_event_datetime( $e['date'], $e['time'] ) ); ?></td>
+      <td data-label="<?php echo esc_attr__( '# of Expected Attendees', 'tta' ); ?>"><?php echo intval( tta_get_expected_attendee_count( $e['ute_id'] ) ); ?></td>
+      <td data-label="<?php echo esc_attr__( 'Status', 'tta' ); ?>"><?php echo esc_html( $status ); ?></td>
+      <td class="tta-toggle-cell" data-label=""><img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/arrow.svg' ); ?>" class="tta-toggle-arrow" width="10" height="10" alt="Toggle"></td>
     </tr>
   <?php endforeach; else : ?>
     <tr><td colspan="5"><?php esc_html_e( 'No upcoming events found.', 'tta' ); ?></td></tr>

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/templates/host-checkin-template.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/templates/host-checkin-template.php
@@ -43,14 +43,12 @@ echo do_shortcode( $header_shortcode );
       <th><?php esc_html_e( 'Event Name', 'tta' ); ?></th>
       <th><?php esc_html_e( 'Date & Time', 'tta' ); ?></th>
       <th><?php esc_html_e( '# of Expected Attendees', 'tta' ); ?></th>
-      <th><?php esc_html_e( 'Status', 'tta' ); ?></th>
       <th></th>
     </tr>
   </thead>
   <tbody>
   <?php if ( $events ) :
     foreach ( $events as $e ) :
-        $status = ( $e['date'] > $today ) ? 'Upcoming' : ( $e['date'] === $today ? 'Today' : 'Past' );
         if ( ! empty( $e['mainimageid'] ) ) {
             $img = wp_get_attachment_image( intval( $e['mainimageid'] ), [50,50] );
         } else {
@@ -62,8 +60,7 @@ echo do_shortcode( $header_shortcode );
       <td data-label="<?php echo esc_attr__( 'Event Name', 'tta' ); ?>"><?php echo esc_html( $e['name'] ); ?></td>
       <td data-label="<?php echo esc_attr__( 'Date & Time', 'tta' ); ?>"><?php echo esc_html( tta_format_event_datetime( $e['date'], $e['time'] ) ); ?></td>
       <td data-label="<?php echo esc_attr__( '# of Expected Attendees', 'tta' ); ?>"><?php echo intval( tta_get_expected_attendee_count( $e['ute_id'] ) ); ?></td>
-      <td data-label="<?php echo esc_attr__( 'Status', 'tta' ); ?>"><?php echo esc_html( $status ); ?></td>
-      <td class="tta-toggle-cell" data-label=""><img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/arrow.svg' ); ?>" class="tta-toggle-arrow" width="10" height="10" alt="Toggle"></td>
+      <td class="tta-toggle-cell" data-label=""><span class="tta-toggle-text"><strong><?php esc_html_e( 'See All Attendees', 'tta' ); ?></strong></span><img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/arrow.svg' ); ?>" class="tta-toggle-arrow" width="10" height="10" alt="Toggle"></td>
     </tr>
   <?php endforeach; else : ?>
     <tr><td colspan="5"><?php esc_html_e( 'No upcoming events found.', 'tta' ); ?></td></tr>

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/templates/host-checkin-template.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/templates/host-checkin-template.php
@@ -39,8 +39,7 @@ echo do_shortcode( $header_shortcode );
 <table class="widefat striped">
   <thead>
     <tr>
-      <th><?php esc_html_e( 'Event Image', 'tta' ); ?></th>
-      <th><?php esc_html_e( 'Event Name', 'tta' ); ?></th>
+      <th><?php esc_html_e( 'Event', 'tta' ); ?></th>
       <th><?php esc_html_e( 'Date & Time', 'tta' ); ?></th>
       <th><?php esc_html_e( '# of Expected Attendees', 'tta' ); ?></th>
       <th></th>
@@ -56,14 +55,16 @@ echo do_shortcode( $header_shortcode );
         }
   ?>
     <tr class="tta-event-row" data-event-ute-id="<?php echo esc_attr( $e['ute_id'] ); ?>">
-      <td data-label="<?php echo esc_attr__( 'Event Image', 'tta' ); ?>"><?php echo $img; ?></td>
-      <td data-label="<?php echo esc_attr__( 'Event Name', 'tta' ); ?>"><?php echo esc_html( $e['name'] ); ?></td>
+      <td class="tta-event-cell" data-label="<?php echo esc_attr__( 'Event', 'tta' ); ?>">
+        <?php echo $img; ?>
+        <div class="tta-event-name"><?php echo esc_html( $e['name'] ); ?></div>
+      </td>
       <td data-label="<?php echo esc_attr__( 'Date & Time', 'tta' ); ?>"><?php echo esc_html( tta_format_event_datetime( $e['date'], $e['time'] ) ); ?></td>
       <td data-label="<?php echo esc_attr__( '# of Expected Attendees', 'tta' ); ?>"><?php echo intval( tta_get_expected_attendee_count( $e['ute_id'] ) ); ?></td>
-      <td class="tta-toggle-cell" data-label=""><span class="tta-toggle-text"><strong><?php esc_html_e( 'See All Attendees', 'tta' ); ?></strong></span><img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/arrow.svg' ); ?>" class="tta-toggle-arrow" width="10" height="10" alt="Toggle"></td>
+      <td class="tta-toggle-cell" data-label=""><span class="tta-toggle-text"><strong><?php esc_html_e( 'See All Attendees', 'tta' ); ?></strong></span><img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/arrow.svg' ); ?>" class="tta-toggle-arrow" width="10" height="10" alt="Toggle"><div class="tta-inline-container"></div></td>
     </tr>
   <?php endforeach; else : ?>
-    <tr><td colspan="5"><?php esc_html_e( 'No upcoming events found.', 'tta' ); ?></td></tr>
+    <tr><td colspan="4"><?php esc_html_e( 'No upcoming events found.', 'tta' ); ?></td></tr>
   <?php endif; ?>
   </tbody>
 </table>

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/views/attendance-list.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/views/attendance-list.php
@@ -37,11 +37,11 @@ if ( ! defined( 'ABSPATH' ) ) exit;
   <?php if ( $attendees ) :
     foreach ( $attendees as $a ) : ?>
     <tr data-attendee-id="<?php echo esc_attr( $a['id'] ); ?>">
-      <td><?php echo esc_html( $a['first_name'] . ' ' . $a['last_name'] ); ?></td>
-      <td><?php echo esc_html( $a['email'] ); ?></td>
-      <td><?php echo intval( $a['attended_count'] ); ?></td>
-      <td><?php echo isset( $a['assistance_note'] ) ? esc_html( $a['assistance_note'] ) : '-'; ?></td>
-      <td class="status-label"><?php echo esc_html( ucwords( str_replace('_',' ', $a['status'] ) ) ); ?></td>
+      <td><span class="tta-info-title"><?php esc_html_e( 'Name:', 'tta' ); ?></span><?php echo esc_html( $a['first_name'] . ' ' . $a['last_name'] ); ?></td>
+      <td><span class="tta-info-title"><?php esc_html_e( 'Email:', 'tta' ); ?></span><?php echo esc_html( $a['email'] ); ?></td>
+      <td><span class="tta-info-title"><?php esc_html_e( 'Events Attended:', 'tta' ); ?></span><?php echo intval( $a['attended_count'] ); ?></td>
+      <td><span class="tta-info-title"><?php esc_html_e( 'Needs Assistance:', 'tta' ); ?></span><?php echo isset( $a['assistance_note'] ) ? esc_html( $a['assistance_note'] ) : '-'; ?></td>
+      <td><span class="tta-info-title"><?php esc_html_e( 'Status:', 'tta' ); ?></span><span class="status-label"><?php echo esc_html( ucwords( str_replace('_',' ', $a['status'] ) ) ); ?></span></td>
       <td>
         <button class="button tta-mark-attendance" data-attendee-id="<?php echo esc_attr( $a['id'] ); ?>" data-status="checked_in"><?php esc_html_e( 'Check In', 'tta' ); ?></button>
         <button class="button tta-mark-attendance" data-attendee-id="<?php echo esc_attr( $a['id'] ); ?>" data-status="no_show"><?php esc_html_e( 'No-Show', 'tta' ); ?></button>

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
@@ -575,7 +575,7 @@ function tta_get_event_attendees( $event_ute_id ) {
               FROM {$att_archive} a
               JOIN {$tickets_archive} t ON a.ticket_id = t.id
              WHERE t.event_ute_id = %s)
-            ORDER BY last_name, first_name";
+            ORDER BY first_name, last_name";
 
     return $wpdb->get_results(
         $wpdb->prepare( $sql, $event_ute_id, $event_ute_id ),
@@ -606,7 +606,7 @@ function tta_get_event_attendees_with_status( $event_ute_id ) {
                FROM {$att_archive} a
                JOIN {$tickets_archive} t ON a.ticket_id = t.id
               WHERE t.event_ute_id = %s)
-            ORDER BY last_name, first_name";
+            ORDER BY first_name, last_name";
 
     $rows = $wpdb->get_results( $wpdb->prepare( $sql, $event_ute_id, $event_ute_id ), ARRAY_A );
 

--- a/docs/EventCheckInAdmin.md
+++ b/docs/EventCheckInAdmin.md
@@ -11,11 +11,13 @@ cards for easier mobile use. Each event row becomes a full-width block with
 labels for its fields, and tapping the block reveals the attendee list just like
 on desktop.
 
-The desktop view drops the former **Status** column to simplify the layout. On
-mobile, the toggle cell displays a bold “See All Attendees” prompt so it’s clear
-where to tap. When expanded, the attendee list now shows labels such as
-**Name**, **Email**, and **Status** before each value to keep the details tied to
-their event.
+The desktop view drops the former **Status** column to simplify the layout and
+combines the image and name into a single **Event** column. On mobile, the
+toggle cell displays a bold “See All Attendees” prompt so it’s clear where to
+tap. When expanded on screens 1199px wide or narrower, the attendee list now
+appears inside the toggle cell itself and shows labels such as **Name**,
+**Email**, and **Status** before each value. These labels are hidden on wider
+screens because the table headers remain visible.
 
 ### Table details
 

--- a/docs/EventCheckInAdmin.md
+++ b/docs/EventCheckInAdmin.md
@@ -6,6 +6,11 @@ no-shows. The page loads event details, a list of ticket holders and buttons to
 update each record via AJAX. Attendance status writes back to the
 `tta_attendees` table and the interface updates instantly without a full refresh.
 
+On screens 1199px wide or narrower, the events table converts into stacked
+cards for easier mobile use. Each event row becomes a full-width block with
+labels for its fields, and tapping the block reveals the attendee list just like
+on desktop.
+
 ### Table details
 
 - Attendees who cancelled or requested a refund no longer appear in the list so

--- a/docs/EventCheckInAdmin.md
+++ b/docs/EventCheckInAdmin.md
@@ -19,6 +19,9 @@ appears inside the toggle cell itself and shows labels such as **Name**,
 **Email**, and **Status** before each value. These labels are hidden on wider
 screens because the table headers remain visible.
 
+Attendees are ordered alphabetically by first name, and expanding a row on
+desktop slides the attendee list into view for a smoother experience.
+
 ### Table details
 
 - Attendees who cancelled or requested a refund no longer appear in the list so

--- a/docs/EventCheckInAdmin.md
+++ b/docs/EventCheckInAdmin.md
@@ -11,6 +11,12 @@ cards for easier mobile use. Each event row becomes a full-width block with
 labels for its fields, and tapping the block reveals the attendee list just like
 on desktop.
 
+The desktop view drops the former **Status** column to simplify the layout. On
+mobile, the toggle cell displays a bold “See All Attendees” prompt so it’s clear
+where to tap. When expanded, the attendee list now shows labels such as
+**Name**, **Email**, and **Status** before each value to keep the details tied to
+their event.
+
 ### Table details
 
 - Attendees who cancelled or requested a refund no longer appear in the list so

--- a/docs/MemberDashboard.md
+++ b/docs/MemberDashboard.md
@@ -3,6 +3,8 @@
 The Member Dashboard is accessible at `/member-dashboard/` via the shortcode `[tta_member_dashboard]`.
 It presents five tabs: **Profile Info**, **Your Upcoming Events**, **Your Waitlist Events**, **Your Past Events**, and **Billing & Membership Info**. Tooltip icons now appear before each field label for quicker context. The tooltip text is displayed instantly on hover using visibility toggles instead of opacity fades. The dashboard's JavaScript and CSS are enqueued whenever the page is viewed so tab switching works even when not logged in.
 
+On screens narrower than 1200px the dashboard switches to a mobile-friendly layout. The sidebar tabs become full-width accordion headers; tapping a header expands its section while collapsing the others. Each tab’s form and fields remain intact inside its accordion panel.
+
 When rendered the shortcode inserts a WPBakery hero banner above the dashboard using `do_shortcode()`. The banner displays **Member Dashboard** across a full-width background image.
 
 If a member is banned the dashboard displays a prominent notice at the top explaining the ban duration and purchases are blocked until it expires.


### PR DESCRIPTION
## Summary
- Turn member dashboard tabs into full-width accordions on screens under 1200px for mobile-friendly viewing
- Hide sidebar and adjust styles for one-column layout on narrow devices
- Document responsive behavior in Member Dashboard docs

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689e2f764230832089af7da786131e95