### PR TITLE
Schedule event reminder emails

### DIFF
--- a/app/public/wp-content/plugins/tta-management-plugin/includes/ajax/handlers/class-ajax-events.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/ajax/handlers/class-ajax-events.php
@@ -343,6 +343,7 @@ class TTA_Ajax_Events {
         }
 
         $page_url = $page_id ? get_permalink( $page_id ) : '';
+        TTA_Email_Reminders::schedule_event_emails( $event_id );
         TTA_Cache::flush();
         wp_send_json_success([ 'message'=>'Event updated!','page_url'=>$page_url ]);
     }

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/email/class-email-reminders.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/email/class-email-reminders.php
@@ -1,0 +1,161 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+/**
+ * Schedule and send event reminder emails.
+ */
+class TTA_Email_Reminders {
+    /** Initialize hooks. */
+    public static function init() {
+        add_action( 'tta_attendee_reminder_email', [ __CLASS__, 'send_attendee_reminder' ], 10, 2 );
+        add_action( 'tta_host_reminder_email', [ __CLASS__, 'send_host_reminder' ], 10, 2 );
+        add_action( 'tta_volunteer_reminder_email', [ __CLASS__, 'send_volunteer_reminder' ], 10, 2 );
+    }
+
+    /**
+     * Schedule reminder emails for an event.
+     *
+     * @param int $event_id Event ID.
+     */
+    public static function schedule_event_emails( $event_id ) {
+        $event_id = intval( $event_id );
+        if ( ! $event_id ) {
+            return;
+        }
+
+        $ute_id = tta_get_event_ute_id( $event_id );
+        if ( ! $ute_id ) {
+            return;
+        }
+
+        $event = tta_get_event_for_email( $ute_id );
+        if ( empty( $event['date'] ) ) {
+            return;
+        }
+
+        $start = explode( '|', $event['time'] ?? '' )[0] ?? '00:00';
+        $tz    = new DateTimeZone( 'America/New_York' );
+        $dt    = DateTime::createFromFormat( 'Y-m-d H:i', $event['date'] . ' ' . $start, $tz );
+        if ( ! $dt ) {
+            return;
+        }
+        $start_ts = $dt->getTimestamp();
+
+        self::schedule_single( $start_ts - DAY_IN_SECONDS, 'tta_attendee_reminder_email', [ $event_id, 'reminder_24hr' ] );
+        self::schedule_single( $start_ts - 3 * HOUR_IN_SECONDS, 'tta_attendee_reminder_email', [ $event_id, 'reminder_2hr' ] );
+        self::schedule_single( $start_ts - DAY_IN_SECONDS, 'tta_host_reminder_email', [ $event_id, 'host_reminder_24hr' ] );
+        self::schedule_single( $start_ts - 3 * HOUR_IN_SECONDS, 'tta_host_reminder_email', [ $event_id, 'host_reminder_2hr' ] );
+        self::schedule_single( $start_ts - DAY_IN_SECONDS, 'tta_volunteer_reminder_email', [ $event_id, 'volunteer_reminder_24hr' ] );
+        self::schedule_single( $start_ts - 3 * HOUR_IN_SECONDS, 'tta_volunteer_reminder_email', [ $event_id, 'volunteer_reminder_2hr' ] );
+    }
+
+    /**
+     * Schedule a single cron event if future and not already scheduled.
+     */
+    protected static function schedule_single( $timestamp, $hook, array $args ) {
+        if ( $timestamp <= time() ) {
+            return;
+        }
+        if ( wp_next_scheduled( $hook, $args ) ) {
+            return;
+        }
+        wp_schedule_single_event( $timestamp, $hook, $args );
+    }
+
+    /**
+     * Send attendee reminder emails.
+     */
+    public static function send_attendee_reminder( $event_id, $template_key ) {
+        $event_id = intval( $event_id );
+        $templates = tta_get_comm_templates();
+        if ( empty( $templates[ $template_key ] ) ) {
+            return;
+        }
+        $ute_id = tta_get_event_ute_id( $event_id );
+        if ( ! $ute_id ) {
+            return;
+        }
+        $event     = tta_get_event_for_email( $ute_id );
+        $attendees = tta_get_event_attendees_with_status( $ute_id );
+        if ( empty( $event ) || empty( $attendees ) ) {
+            return;
+        }
+        $tpl     = $templates[ $template_key ];
+        $headers = [ 'Content-Type: text/html; charset=UTF-8' ];
+        foreach ( $attendees as $att ) {
+            $context = [
+                'user_email' => sanitize_email( $att['email'] ),
+                'first_name' => sanitize_text_field( $att['first_name'] ),
+                'last_name'  => sanitize_text_field( $att['last_name'] ),
+                'member'     => [],
+            ];
+            $tokens      = self::build_tokens( $event, $context, [ $att ] );
+            $subject_raw = tta_expand_anchor_tokens( $tpl['email_subject'], $tokens );
+            $subject     = tta_strip_bold( strtr( $subject_raw, $tokens ) );
+            $body_raw    = tta_expand_anchor_tokens( $tpl['email_body'], $tokens );
+            $body_txt    = tta_convert_bold( tta_convert_links( strtr( $body_raw, $tokens ) ) );
+            $body        = nl2br( $body_txt );
+            wp_mail( $context['user_email'], $subject, $body, $headers );
+        }
+    }
+
+    /** Send host reminder emails. */
+    public static function send_host_reminder( $event_id, $template_key ) {
+        $emails = tta_get_event_host_volunteer_emails( $event_id, 'host' );
+        self::send_generic_reminder( $event_id, $template_key, $emails );
+    }
+
+    /** Send volunteer reminder emails. */
+    public static function send_volunteer_reminder( $event_id, $template_key ) {
+        $emails = tta_get_event_host_volunteer_emails( $event_id, 'volunteer' );
+        self::send_generic_reminder( $event_id, $template_key, $emails );
+    }
+
+    /**
+     * Generic reminder sender for hosts and volunteers.
+     *
+     * @param int      $event_id     Event ID.
+     * @param string   $template_key Template key.
+     * @param string[] $emails       Recipient list.
+     */
+    protected static function send_generic_reminder( $event_id, $template_key, array $emails ) {
+        if ( empty( $emails ) ) {
+            return;
+        }
+        $templates = tta_get_comm_templates();
+        if ( empty( $templates[ $template_key ] ) ) {
+            return;
+        }
+        $ute_id = tta_get_event_ute_id( $event_id );
+        if ( ! $ute_id ) {
+            return;
+        }
+        $event = tta_get_event_for_email( $ute_id );
+        if ( empty( $event ) ) {
+            return;
+        }
+        $tpl     = $templates[ $template_key ];
+        $headers = [ 'Content-Type: text/html; charset=UTF-8' ];
+        foreach ( $emails as $email ) {
+            $context = [ 'user_email' => sanitize_email( $email ), 'first_name' => '', 'last_name' => '', 'member' => [] ];
+            $tokens  = self::build_tokens( $event, $context, [] );
+            $subject_raw = tta_expand_anchor_tokens( $tpl['email_subject'], $tokens );
+            $subject     = tta_strip_bold( strtr( $subject_raw, $tokens ) );
+            $body_raw    = tta_expand_anchor_tokens( $tpl['email_body'], $tokens );
+            $body_txt    = tta_convert_bold( tta_convert_links( strtr( $body_raw, $tokens ) ) );
+            $body        = nl2br( $body_txt );
+            wp_mail( $email, $subject, $body, $headers );
+        }
+    }
+
+    /**
+     * Proxy to the email handler's token builder.
+     */
+    protected static function build_tokens( array $event, array $member, array $attendees, array $refund = [] ) {
+        $email = TTA_Email_Handler::get_instance();
+        $ref   = new ReflectionClass( $email );
+        $m     = $ref->getMethod( 'build_tokens' );
+        $m->setAccessible( true );
+        return $m->invoke( $email, $event, $member, $attendees, $refund );
+    }
+}

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
@@ -941,20 +941,22 @@ function tta_get_event_attendee_image_ids( $event_id ) {
 }
 
 /**
- * Retrieve email addresses for all hosts and volunteers of an event.
+ * Retrieve email addresses for hosts and/or volunteers of an event.
  *
  * Supports both numeric user IDs and legacy name-based values.
  *
- * @param int $event_id Event ID.
+ * @param int         $event_id Event ID.
+ * @param string|null $role     Optional role filter: 'host' or 'volunteer'.
  * @return string[] List of unique emails.
  */
-function tta_get_event_host_volunteer_emails( $event_id ) {
+function tta_get_event_host_volunteer_emails( $event_id, $role = null ) {
     $event_id = intval( $event_id );
     if ( ! $event_id ) {
         return [];
     }
 
-    $cache_key = 'event_host_vol_emails_' . $event_id;
+    $role      = $role ? strtolower( $role ) : null;
+    $cache_key = 'event_host_vol_emails_' . $event_id . '_' . ( $role ?: 'all' );
     $cached    = TTA_Cache::get( $cache_key );
     if ( false !== $cached ) {
         return $cached;
@@ -996,18 +998,29 @@ function tta_get_event_host_volunteer_emails( $event_id ) {
     list( $host_ids, $host_names ) = $parse( $row['hosts'] ?? '' );
     list( $vol_ids,  $vol_names  ) = $parse( $row['volunteers'] ?? '' );
 
-    $emails = [];
+    $emails    = [];
+    $id_list   = [];
+    $name_list = [];
 
-    $id_list = array_unique( array_merge( $host_ids, $vol_ids ) );
+    if ( 'host' === $role ) {
+        $id_list   = $host_ids;
+        $name_list = $host_names;
+    } elseif ( 'volunteer' === $role ) {
+        $id_list   = $vol_ids;
+        $name_list = $vol_names;
+    } else {
+        $id_list   = array_unique( array_merge( $host_ids, $vol_ids ) );
+        $name_list = array_unique( array_merge( $host_names, $vol_names ) );
+    }
+
     if ( $id_list ) {
         $placeholders = implode( ',', array_fill( 0, count( $id_list ), '%d' ) );
-        $rows = $wpdb->get_col( $wpdb->prepare( "SELECT email FROM {$members_table} WHERE wpuserid IN ($placeholders)", $id_list ) );
+        $rows         = $wpdb->get_col( $wpdb->prepare( "SELECT email FROM {$members_table} WHERE wpuserid IN ($placeholders)", $id_list ) );
         foreach ( $rows as $em ) {
             $emails[] = sanitize_email( $em );
         }
     }
 
-    $name_list = array_unique( array_merge( $host_names, $vol_names ) );
     foreach ( $name_list as $nm ) {
         $rows = $wpdb->get_col( $wpdb->prepare( "SELECT email FROM {$members_table} WHERE LOWER(CONCAT(first_name,' ',last_name)) = %s", $nm ) );
         foreach ( $rows as $em ) {

--- a/app/public/wp-content/plugins/tta-management-plugin/tests/EmailReminderScheduleTest.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/tests/EmailReminderScheduleTest.php
@@ -1,0 +1,70 @@
+<?php
+use PHPUnit\Framework\TestCase;
+if ( ! defined( 'ARRAY_A' ) ) { define( 'ARRAY_A', 'ARRAY_A' ); }
+
+class EmailReminderScheduleTest extends TestCase {
+    protected function setUp(): void {
+        $GLOBALS['scheduled'] = [];
+        if ( ! defined( 'ABSPATH' ) ) { define( 'ABSPATH', sys_get_temp_dir() . '/wp/' ); }
+        if ( ! defined( 'DAY_IN_SECONDS' ) ) { define( 'DAY_IN_SECONDS', 86400 ); }
+        if ( ! defined( 'HOUR_IN_SECONDS' ) ) { define( 'HOUR_IN_SECONDS', 3600 ); }
+        if ( ! function_exists( 'wp_schedule_single_event' ) ) {
+            function wp_schedule_single_event( $ts, $hook, $args = [] ) {
+                $GLOBALS['scheduled'][] = [ $ts, $hook, $args ];
+            }
+        }
+        if ( ! function_exists( 'wp_next_scheduled' ) ) {
+            function wp_next_scheduled( $hook, $args = [] ) {
+                return false;
+            }
+        }
+        $GLOBALS['wpdb'] = new class {
+            public $prefix = '';
+            public function get_var() { return 'ute_1'; }
+            public function get_row() {
+                return [
+                    'id' => 1,
+                    'name' => 'Test',
+                    'date' => '2030-08-15',
+                    'time' => '18:00|20:00',
+                    'address' => '',
+                    'page_id' => 0,
+                    'type' => '',
+                    'venuename' => '',
+                    'venueurl' => '',
+                    'baseeventcost' => 0,
+                    'discountedmembercost' => 0,
+                    'premiummembercost' => 0,
+                    'host_notes' => '',
+                ];
+            }
+            public function prepare( $query, ...$args ) { return $query; }
+        };
+        if ( ! function_exists( 'sanitize_text_field' ) ) {
+            function sanitize_text_field( $v ) { return $v; }
+        }
+        if ( ! function_exists( 'sanitize_textarea_field' ) ) {
+            function sanitize_textarea_field( $v ) { return $v; }
+        }
+        if ( ! function_exists( 'esc_url_raw' ) ) {
+            function esc_url_raw( $v ) { return $v; }
+        }
+        if ( ! function_exists( 'get_permalink' ) ) {
+            function get_permalink( $id ) { return ''; }
+        }
+    }
+
+    protected function tearDown(): void {
+        $GLOBALS['scheduled'] = [];
+    }
+
+    public function test_schedule_event_emails_creates_six_events() {
+        require_once __DIR__ . '/../includes/email/class-email-reminders.php';
+        TTA_Email_Reminders::schedule_event_emails( 1 );
+        $this->assertCount( 6, $GLOBALS['scheduled'] );
+        $hooks = array_column( $GLOBALS['scheduled'], 1 );
+        $this->assertContains( 'tta_attendee_reminder_email', $hooks );
+        $this->assertContains( 'tta_host_reminder_email', $hooks );
+        $this->assertContains( 'tta_volunteer_reminder_email', $hooks );
+    }
+}

--- a/app/public/wp-content/plugins/tta-management-plugin/trying-to-adult-management-plugin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/trying-to-adult-management-plugin.php
@@ -143,6 +143,7 @@ require_once TTA_PLUGIN_DIR . 'includes/frontend/class-checkout-page-manager.php
 require_once TTA_PLUGIN_DIR . 'includes/frontend/class-events-list-page.php';
 require_once TTA_PLUGIN_DIR . 'includes/api/class-authorizenet-api.php';
 require_once TTA_PLUGIN_DIR . 'includes/email/class-email-handler.php';
+require_once TTA_PLUGIN_DIR . 'includes/email/class-email-reminders.php';
 require_once TTA_PLUGIN_DIR . 'includes/sms/class-sms-handler.php';
 require_once TTA_PLUGIN_DIR . 'includes/waitlist/class-waitlist.php';
 require_once TTA_PLUGIN_DIR . 'includes/ajax/class-ajax-handler.php';
@@ -213,6 +214,7 @@ class TTA_Plugin {
         // Notification handlers
         TTA_Email_Handler::get_instance();
         TTA_SMS_Handler::get_instance();
+        TTA_Email_Reminders::init();
 
         // Expired cart cleanup
         TTA_Cart_Cleanup::init();

--- a/docs/EventCreationAdmin.md
+++ b/docs/EventCreationAdmin.md
@@ -2,6 +2,8 @@
 
 Administrators manage events from the **TTA Events** pages. The editor collects standard details like the name, date and location along with optional images and links.
 
+After an event is saved, the plugin automatically schedules reminder emails for hosts, volunteers, and attendees. These messages are queued to send 24 hours and 3 hours before the event start time and always use the latest host, volunteer, and attendee lists when they run.
+
 ## Hosts and Volunteers
 
 Host and volunteer fields use an autocomplete list populated from members whose type is Volunteer, Admin or Super Admin. When the form is saved each name is converted to the member's WordPress user ID and stored in the `hosts` and `volunteers` columns. Older records that still contain names are handled automatically.


### PR DESCRIPTION
## Summary
- schedule attendee, host, and volunteer reminder emails 24 and 3 hours before events
- reuse existing 2-hour reminder templates and update admin docs
- document automatic reminder scheduling

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689f8e92eb8c8320883e2b1d2198bbb5