### PR TITLE
Add mobile-friendly payment history for narrow screens

### DIFF
--- a/app/public/wp-content/plugins/tta-management-plugin/assets/css/frontend/member-dashboard.css
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/css/frontend/member-dashboard.css
@@ -365,6 +365,10 @@
   font-weight:bold;
 }
 
+.tta-billing-history-mobile {
+  display: none;
+}
+
 /* Responsive mobile layout */
 @media (max-width: 1199px) {
   .tta-member-dashboard {
@@ -487,6 +491,23 @@
     padding: 15px 0;
     gap: 15px;
     margin-bottom: 10px;
+  }
+  .tta-billing-history--desktop {
+    display: none;
+  }
+  .tta-billing-history-mobile {
+    display: block;
+  }
+  .tta-billing-history-mobile-row {
+    border-bottom: 1px solid #ddd;
+    padding: 15px 0;
+    margin-bottom: 10px;
+  }
+  .tta-bhm-field {
+    margin-bottom: 4px;
+  }
+  .tta-bhm-field:last-child {
+    margin-bottom: 0;
   }
 }
 

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/views/tab-billing.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/views/tab-billing.php
@@ -237,7 +237,7 @@
   $history = tta_get_member_billing_history( get_current_user_id() );
   if ( $history ) : ?>
     <h4><?php esc_html_e( 'Payment History', 'tta' ); ?></h4>
-    <table class="widefat striped tta-billing-history">
+    <table class="widefat striped tta-billing-history tta-billing-history--desktop">
       <thead>
         <tr>
           <th><?php esc_html_e( 'Date', 'tta' ); ?></th>
@@ -269,6 +269,25 @@
         <?php endforeach; ?>
       </tbody>
     </table>
+
+    <div class="tta-billing-history-mobile">
+      <?php foreach ( $history as $row ) : ?>
+        <div class="tta-billing-history-mobile-row">
+          <div class="tta-bhm-field tta-bhm-date"><strong><?php esc_html_e( 'Date', 'tta' ); ?>:</strong> <?php echo esc_html( date_i18n( 'F j, Y', strtotime( $row['date'] ) ) ); ?></div>
+          <div class="tta-bhm-field tta-bhm-item"><strong><?php esc_html_e( 'Item', 'tta' ); ?>:</strong> 
+            <?php if ( ! empty( $row['url'] ) ) : ?>
+              <a href="<?php echo esc_url( $row['url'] ); ?>"><?php echo esc_html( $row['description'] ); ?></a>
+            <?php else : ?>
+              <?php echo esc_html( $row['description'] ); ?>
+            <?php endif; ?>
+          </div>
+          <div class="tta-bhm-field tta-bhm-amount"><strong><?php esc_html_e( 'Amount', 'tta' ); ?>:</strong> $<?php echo esc_html( number_format( $row['amount'], 2 ) ); ?></div>
+          <div class="tta-bhm-field tta-bhm-transaction"><strong><?php esc_html_e( 'Transaction ID', 'tta' ); ?>:</strong> <?php echo esc_html( $row['transaction_id'] ?? '' ); ?></div>
+          <div class="tta-bhm-field tta-bhm-type"><strong><?php esc_html_e( 'Type', 'tta' ); ?>:</strong> <?php echo esc_html( ucwords( $row['type'] ) ); ?></div>
+          <div class="tta-bhm-field tta-bhm-method"><strong><?php esc_html_e( 'Payment Method', 'tta' ); ?>:</strong> <?php echo esc_html( $row['method'] ); ?></div>
+        </div>
+      <?php endforeach; ?>
+    </div>
   <?php else : ?>
     <p><?php esc_html_e( 'No transactions found.', 'tta' ); ?></p>
   <?php endif; ?>

--- a/docs/MemberDashboard.md
+++ b/docs/MemberDashboard.md
@@ -66,7 +66,7 @@ their card information directly on the dashboard.
 If no membership is active and there is no payment issue, a simple message
 "You do not currently have a paid membership." appears instead of the controls.
 
-Below the membership controls is a **Payment History** table. It lists all
+Below the membership controls is a **Payment History** table. On screens narrower than 1200px the table is replaced with a stacked mobile layout for readability. It lists all
 transactions in chronological order including event purchases logged in the
 `tta_transactions` table, any refunds processed, and monthly membership charges
 retrieved from the Authorize.Net API. Refund transactions now appear alongside


### PR DESCRIPTION
## Summary
- show billing history as a responsive stacked list when screen width is 1200px or less
- add CSS to hide desktop table and style mobile rows
- document payment history mobile layout in Member Dashboard doc

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689fab09ab608320bcfed5f22f3f5bab