### PR TITLE
Extend ticket reservation timeout to 10 minutes

### DIFF
--- a/app/public/wp-content/plugins/tta-management-plugin/includes/cart/class-cart.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/cart/class-cart.php
@@ -182,7 +182,7 @@ class TTA_Cart {
         ['%d','%f'],['%d','%d']
       );
     } else {
-      $expire = gmdate( 'Y-m-d H:i:s', (int) current_time( 'timestamp', true ) + 300 );
+      $expire = gmdate( 'Y-m-d H:i:s', (int) current_time( 'timestamp', true ) + 600 );
       $this->wpdb->insert(
         $this->items_table,
         [
@@ -284,7 +284,7 @@ class TTA_Cart {
         ['%d'],['%d','%d']
       );
     } else {
-      $expire = gmdate( 'Y-m-d H:i:s', (int) current_time( 'timestamp', true ) + 300 );
+      $expire = gmdate( 'Y-m-d H:i:s', (int) current_time( 'timestamp', true ) + 600 );
       $this->wpdb->insert(
         $this->items_table,
         [

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
@@ -4106,7 +4106,7 @@ function tta_render_cart_contents( TTA_Cart $cart, $discount_codes = [], array $
                     </th>
                     <?php if ( $has_tickets ) : ?>
                     <th>
-                            <span class="tta-tooltip-icon" data-tooltip="<?php echo esc_attr( 'We reserve your ticket for 5 minutes so events don\'t oversell. After 5 minutes it becomes available to others.' ); ?>">
+                            <span class="tta-tooltip-icon" data-tooltip="<?php echo esc_attr( 'We reserve your ticket for 10 minutes so events don\'t oversell. After 10 minutes it becomes available to others.' ); ?>">
                                 <img src="<?php echo esc_url( ( defined( 'TTA_PLUGIN_URL' ) ? TTA_PLUGIN_URL : '' ) . 'assets/images/admin/question.svg' ); ?>" alt="?">
                         </span>
                         <?php esc_html_e( 'Ticket Reserved for…', 'tta' ); ?>
@@ -4287,7 +4287,7 @@ function tta_render_checkout_summary( TTA_Cart $cart, $discount_codes = [] ) {
                     </th>
                     <?php if ( $has_tickets ) : ?>
                     <th>
-                        <span class="tta-tooltip-icon" data-tooltip="<?php echo esc_attr( "We reserve your ticket for 5 minutes so events don't oversell. After 5 minutes it becomes available to others." ); ?>">
+                        <span class="tta-tooltip-icon" data-tooltip="<?php echo esc_attr( "We reserve your ticket for 10 minutes so events don't oversell. After 10 minutes it becomes available to others." ); ?>">
                             <img src="<?php echo esc_url( ( defined( 'TTA_PLUGIN_URL' ) ? TTA_PLUGIN_URL : '' ) . 'assets/images/admin/question.svg' ); ?>" alt="?">
                         </span>
                         <?php esc_html_e( 'Ticket Reserved for…', 'tta' ); ?>

--- a/app/public/wp-content/plugins/tta-management-plugin/tests/RefundTicketReleaseTest.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/tests/RefundTicketReleaseTest.php
@@ -39,7 +39,7 @@ class RefundTicketReleaseTest extends TestCase {
         global $wpdb;
         $wpdb = new DummyWpdbRefund();
         $wpdb->data['wp_tta_tickets'] = [ ['id'=>1,'event_ute_id'=>'ev1','ticketlimit'=>0] ];
-        $wpdb->data['wp_tta_cart_items'] = [ ['ticket_id'=>1,'expires_at'=>date('Y-m-d H:i:s', time()+300)] ];
+        $wpdb->data['wp_tta_cart_items'] = [ ['ticket_id'=>1,'expires_at'=>date('Y-m-d H:i:s', time()+600)] ];
         if (!function_exists('current_time')) {
             function current_time( $type = 'mysql', $gmt = false ) {
                 return 'timestamp' === $type ? time() : gmdate( 'Y-m-d H:i:s' );

--- a/docs/CartFlow.md
+++ b/docs/CartFlow.md
@@ -23,7 +23,7 @@ This document summarizes the current logic around the cart and checkout process 
    - Premium members cannot add another membership at all. Attempts to add Basic or Premium memberships are rejected.
    - When the cart only contains a membership, the table hides the **Ticket Reserved for…** column and the first column heading becomes **Event or Item**. Membership pricing shows "Per Month" in the price and subtotal columns, and the total row also displays "Per Month". Column spans adjust so the table remains aligned without the countdown column.
    - If both a membership and tickets are present, the total row displays the first charge (e.g. `$15.00 today, $5 Per Month`) so customers understand future recurring payments.
-   - A dedicated **Ticket Reserved for…** column displays a live five minute countdown for ticket rows.
+   - A dedicated **Ticket Reserved for…** column displays a live ten minute countdown for ticket rows.
   - The Quantity column enforces the per‑member limit configured for each ticket.
    - Discount codes are applied via an **Apply Discount** button. Multiple codes can be active and are split across matching event tickets. Active codes list the related event name in parentheses and appear beneath the cart total for easy removal.
    - The Price column always shows the base cost (e.g. `$20 x 2` when quantity is two). Subtotals strike through the original amount when discounts are applied.


### PR DESCRIPTION
## Summary
- Hold cart reservations for 10 minutes instead of 5.
- Update tooltip messaging, docs, and tests to match new hold time.

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68a07f8774a48320b56203d9c3e881e6