### PR TITLE
Fix homepage alert bar countdown conflict

### DIFF
--- a/app/public/wp-content/plugins/tta-management-plugin/assets/js/frontend/homepage-shortcode.js
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/js/frontend/homepage-shortcode.js
@@ -40,7 +40,7 @@
             setTimeout(cycle, 5000);
         }
 
-        var $cd = $('.tta-countdown');
+        var $cd = $('.tta-next-event__countdown .tta-countdown');
         if ($cd.length) {
             var target = parseInt($cd.data('time'), 10) * 1000;
             function plural(v, s, p){ return v + ' ' + (v === 1 ? s : p); }


### PR DESCRIPTION
## Summary
- ensure homepage countdown script only updates next event timer

## Testing
- `apt-get install -y php-cli`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68a08e69f6548320a6cb077fefebe19b