### PR TITLE
Refine banned member reinstatement flow

### DIFF
--- a/app/public/wp-content/plugins/tta-management-plugin/assets/css/frontend/style.css
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/css/frontend/style.css
@@ -21,6 +21,35 @@
   font-weight:700;
 }
 
+.tta-alert-overlay{
+  position:fixed;
+  top:0;left:0;right:0;bottom:0;
+  background:rgba(0,0,0,0.6);
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  z-index:10000;
+  padding:10px;
+  box-sizing:border-box;
+}
+.tta-alert-modal{
+  position:relative;
+  background:#fff;
+  padding:20px;
+  border-radius:4px;
+  max-width:400px;
+  width:100%;
+}
+.tta-alert-close{
+  position:absolute;
+  top:5px;
+  right:10px;
+  background:none;
+  border:0;
+  font-size:20px;
+  cursor:pointer;
+}
+
 /* Become a Member page */
 .tta-become-member-wrap {
   max-width: 800px;

--- a/app/public/wp-content/plugins/tta-management-plugin/assets/js/frontend/alert-bar.js
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/js/frontend/alert-bar.js
@@ -1,9 +1,12 @@
 jQuery(function($){
     var data = window.ttaAlertBarData || {};
     if(data.is_banned){
-        var $bar = $('<div id="tta-alert-bar" class="tta-alert-bar tta-alert-banned"><span class="tta-alert-message"></span><a class="tta-alert-button"></a></div>');
-        $bar.find('.tta-alert-message').text(data.banned_message || '');
-        $bar.find('.tta-alert-button').text(data.reentry_label || '').attr('href', data.reentry_url || '#');
+        var $bar = $('<div id="tta-alert-bar" class="tta-alert-bar tta-alert-banned"><span class="tta-alert-message"></span></div>');
+        $bar.find('.tta-alert-message').html(data.banned_message || '');
+        if(data.show_button){
+            var $btn = $('<a class="tta-alert-button"></a>').text(data.reentry_label||'').attr('href',data.reentry_url||'#');
+            $bar.append($btn);
+        }
         $('body').append($bar);
         return;
     }

--- a/app/public/wp-content/plugins/tta-management-plugin/assets/js/frontend/tta-cart.js
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/js/frontend/tta-cart.js
@@ -1,5 +1,16 @@
 jQuery(function($){
   var countdownTimers = [];
+
+  function ttaHtmlAlert(msg){
+    var $overlay = $('#tta-html-alert-overlay');
+    if(!$overlay.length){
+      $overlay = $('<div id="tta-html-alert-overlay" class="tta-alert-overlay" style="display:none;"><div class="tta-alert-modal"><button type="button" class="tta-alert-close" aria-label="Close">×</button><div class="tta-alert-content"></div></div></div>').appendTo('body');
+      $overlay.on('click', '.tta-alert-close', function(){ $overlay.fadeOut(200); });
+      $overlay.on('click', function(e){ if(e.target === this){ $overlay.fadeOut(200); } });
+    }
+    $overlay.find('.tta-alert-content').html(msg);
+    $overlay.fadeIn(200);
+  }
   // Quantity controls
   $('.tta-qty-increase').on('click', function(){
     var $input = $(this).closest('.tta-ticket-quantity').find('.tta-qty-input');
@@ -59,7 +70,7 @@ jQuery(function($){
           window.location.href = res.data.cart_url;
         }
       } else {
-        alert( res.data.message || 'Error adding to cart.' );
+        ttaHtmlAlert( res.data.message || 'Error adding to cart.' );
       }
     }, 'json');
   });
@@ -73,7 +84,7 @@ jQuery(function($){
       if(res.success){
         window.location.href = res.data.cart_url;
       } else {
-        alert(res.data.message || 'Error adding membership.');
+        ttaHtmlAlert(res.data.message || 'Error adding membership.');
       }
     }, 'json');
   }
@@ -137,7 +148,7 @@ jQuery(function($){
             setTimeout(function(){ $n.fadeOut(200); }, 4000);
           });
         } else {
-          alert(res.data.message || 'Error updating cart.');
+          ttaHtmlAlert(res.data.message || 'Error updating cart.');
           if($target.length){ $target.fadeTo(200,1); }
         }
         startTimers();

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-comms-admin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-comms-admin.php
@@ -64,6 +64,15 @@ class TTA_Comms_Admin {
                 'email_body'  => __('Your refund request was approved and has been processed. We\'re sorry you couldn\'t make it, but we hope to see you at future events!', 'tta'),
                 'sms_text'    => '',
             ],
+            'banned_reinstatement' => [
+                'label'       => __( 'Banned Reinstatement', 'tta' ),
+                'type'        => 'External',
+                'category'    => 'Ban',
+                'description' => __( 'Sent when a member purchases a Re-Entry Ticket to lift a ban.', 'tta' ),
+                'email_subject' => __( 'Welcome back!', 'tta' ),
+                'email_body'  => __( 'Your account has been reinstated and you may now purchase event tickets.', 'tta' ),
+                'sms_text'    => '',
+            ],
             'event_sold_out' => [
                 'label'       => __('Event Sold Out', 'tta'),
                 'type'        => 'Internal',

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/views/members-create.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/views/members-create.php
@@ -476,6 +476,7 @@ if ( ! defined( 'ABSPATH' ) ) {
                         <select name="ban_status" id="ban_status">
                             <option value="none">Not Banned</option>
                             <option value="indefinite">Banned Indefinitely</option>
+                            <option value="reentry">Banned Until Purchasing Re-Entry Product</option>
                             <option value="1week">1-Week Ban</option>
                             <option value="2week">2-Week Ban</option>
                             <option value="3week">3-Week Ban</option>

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/views/members-edit.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/views/members-edit.php
@@ -541,16 +541,22 @@ wp_enqueue_media();
                     <?php
                     $ban_opt = 'none';
                     if ( $member['banned_until'] ) {
-                        $diff = strtotime( $member['banned_until'] ) - time();
-                        if ( $diff > 0 ) {
-                            if ( $diff >= 2419200 ) {
-                                $ban_opt = 'indefinite';
-                            } elseif ( $diff >= 1814400 ) {
-                                $ban_opt = '3week';
-                            } elseif ( $diff >= 1209600 ) {
-                                $ban_opt = '2week';
-                            } elseif ( $diff >= 604800 ) {
-                                $ban_opt = '1week';
+                        if ( TTA_BAN_UNTIL_REENTRY === $member['banned_until'] ) {
+                            $ban_opt = 'reentry';
+                        } elseif ( TTA_BAN_UNTIL_INDEFINITE === $member['banned_until'] ) {
+                            $ban_opt = 'indefinite';
+                        } else {
+                            $diff = strtotime( $member['banned_until'] ) - time();
+                            if ( $diff > 0 ) {
+                                if ( $diff >= 2419200 ) {
+                                    $ban_opt = '4week';
+                                } elseif ( $diff >= 1814400 ) {
+                                    $ban_opt = '3week';
+                                } elseif ( $diff >= 1209600 ) {
+                                    $ban_opt = '2week';
+                                } elseif ( $diff >= 604800 ) {
+                                    $ban_opt = '1week';
+                                }
                             }
                         }
                     }
@@ -558,6 +564,7 @@ wp_enqueue_media();
                     <select name="ban_status" id="ban_status">
                         <option value="none" <?php selected( $ban_opt, 'none' ); ?>>Not Banned</option>
                         <option value="indefinite" <?php selected( $ban_opt, 'indefinite' ); ?>>Banned Indefinitely</option>
+                        <option value="reentry" <?php selected( $ban_opt, 'reentry' ); ?>>Banned Until Purchasing Re-Entry Product</option>
                         <option value="1week" <?php selected( $ban_opt, '1week' ); ?>>1-Week Ban</option>
                         <option value="2week" <?php selected( $ban_opt, '2week' ); ?>>2-Week Ban</option>
                         <option value="3week" <?php selected( $ban_opt, '3week' ); ?>>3-Week Ban</option>

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/ajax/handlers/class-ajax-cart.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/ajax/handlers/class-ajax-cart.php
@@ -38,7 +38,13 @@ class TTA_Ajax_Cart {
                 $membership_level = $lvl;
             }
             if ( tta_user_is_banned( get_current_user_id() ) ) {
-                wp_send_json_error( [ 'message' => __( 'You are currently banned from purchasing tickets.', 'tta' ) ] );
+                $ban = tta_get_ban_message( get_current_user_id() );
+                $msg = $ban['message'];
+                if ( ! empty( $ban['button'] ) ) {
+                    $url = add_query_arg( 'reentry', '1', home_url( '/checkout' ) );
+                    $msg .= ' <a class="tta-alert-button" href="' . esc_url( $url ) . '">' . esc_html__( 'Purchase Re-entry Ticket', 'tta' ) . '</a>';
+                }
+                wp_send_json_error( [ 'message' => $msg ] );
             }
         }
 

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/ajax/handlers/class-ajax-checkout.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/ajax/handlers/class-ajax-checkout.php
@@ -80,6 +80,7 @@ class TTA_Ajax_Checkout {
 
             if ( 'reentry' === $membership_level ) {
                 tta_unban_user( get_current_user_id() );
+                tta_send_banned_reinstatement_email( get_current_user_id() );
                 unset( $_SESSION['tta_membership_purchase'] );
             } else {
                 $existing_sub = tta_get_user_subscription_id( get_current_user_id() );

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/ajax/handlers/class-ajax-members.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/ajax/handlers/class-ajax-members.php
@@ -52,20 +52,28 @@ class TTA_Ajax_Members {
 
         $hide_att      = ! empty( $_POST['hide_event_attendance'] ) ? 1 : 0;
         $ban_status    = sanitize_text_field( $_POST['ban_status'] ?? 'none' );
+        $ban_weeks     = 0;
         switch ( $ban_status ) {
             case 'indefinite':
-                $banned_until = '9999-12-31 23:59:59';
+                $banned_until = TTA_BAN_UNTIL_INDEFINITE;
+                break;
+            case 'reentry':
+                $banned_until = TTA_BAN_UNTIL_REENTRY;
                 break;
             case '1week':
+                $ban_weeks   = 1;
                 $banned_until = date( 'Y-m-d H:i:s', time() + WEEK_IN_SECONDS );
                 break;
             case '2week':
+                $ban_weeks   = 2;
                 $banned_until = date( 'Y-m-d H:i:s', time() + 2 * WEEK_IN_SECONDS );
                 break;
             case '3week':
+                $ban_weeks   = 3;
                 $banned_until = date( 'Y-m-d H:i:s', time() + 3 * WEEK_IN_SECONDS );
                 break;
             case '4week':
+                $ban_weeks   = 4;
                 $banned_until = date( 'Y-m-d H:i:s', time() + 4 * WEEK_IN_SECONDS );
                 break;
             default:
@@ -199,6 +207,11 @@ class TTA_Ajax_Members {
             update_user_meta( $wp_user_id, 'profileimgid', $aid );
         }
 
+        wp_clear_scheduled_hook( 'tta_reinstate_member', [ intval( $wp_user_id ) ] );
+        if ( $ban_weeks > 0 ) {
+            wp_schedule_single_event( strtotime( $banned_until ), 'tta_reinstate_member', [ intval( $wp_user_id ) ] );
+        }
+
         // Clear caches so attendee lists stay fresh
         TTA_Cache::flush();
 
@@ -290,20 +303,28 @@ class TTA_Ajax_Members {
 
         $hide_att         = ! empty( $_POST['hide_event_attendance'] ) ? 1 : 0;
         $ban_status       = sanitize_text_field( $_POST['ban_status'] ?? 'none' );
+        $ban_weeks        = 0;
         switch ( $ban_status ) {
             case 'indefinite':
-                $banned_until = '9999-12-31 23:59:59';
+                $banned_until = TTA_BAN_UNTIL_INDEFINITE;
+                break;
+            case 'reentry':
+                $banned_until = TTA_BAN_UNTIL_REENTRY;
                 break;
             case '1week':
+                $ban_weeks   = 1;
                 $banned_until = date( 'Y-m-d H:i:s', time() + WEEK_IN_SECONDS );
                 break;
             case '2week':
+                $ban_weeks   = 2;
                 $banned_until = date( 'Y-m-d H:i:s', time() + 2 * WEEK_IN_SECONDS );
                 break;
             case '3week':
+                $ban_weeks   = 3;
                 $banned_until = date( 'Y-m-d H:i:s', time() + 3 * WEEK_IN_SECONDS );
                 break;
             case '4week':
+                $ban_weeks   = 4;
                 $banned_until = date( 'Y-m-d H:i:s', time() + 4 * WEEK_IN_SECONDS );
                 break;
             default:
@@ -384,6 +405,19 @@ class TTA_Ajax_Members {
                     'ID'         => $wp_user_id,
                     'user_email' => $member_row['email'],
                 ]);
+            }
+
+            wp_clear_scheduled_hook( 'tta_reinstate_member', [ $wp_user_id ] );
+            if ( $ban_weeks > 0 ) {
+                wp_schedule_single_event( strtotime( $banned_until ), 'tta_reinstate_member', [ $wp_user_id ] );
+            }
+            if ( 'indefinite' === $ban_status ) {
+                $sub_id = tta_get_user_subscription_id( $wp_user_id );
+                if ( $sub_id ) {
+                    $api = new TTA_AuthorizeNet_API();
+                    $api->cancel_subscription( $sub_id );
+                    tta_update_user_subscription_status( $wp_user_id, 'cancelled' );
+                }
             }
         }
 

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/ajax/handlers/class-ajax-membership.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/ajax/handlers/class-ajax-membership.php
@@ -21,7 +21,13 @@ class TTA_Ajax_Membership {
         }
         $context = tta_get_current_user_context();
         if ( $context['member'] && tta_user_is_banned( $context['wp_user_id'] ) ) {
-            wp_send_json_error( [ 'message' => __( 'You are currently banned from purchasing a membership.', 'tta' ) ] );
+            $ban = tta_get_ban_message( $context['wp_user_id'] );
+            $msg = $ban['message'];
+            if ( ! empty( $ban['button'] ) ) {
+                $url = add_query_arg( 'reentry', '1', home_url( '/checkout' ) );
+                $msg .= ' <a class="tta-alert-button" href="' . esc_url( $url ) . '">' . esc_html__( 'Purchase Re-entry Ticket', 'tta' ) . '</a>';
+            }
+            wp_send_json_error( [ 'message' => $msg ] );
         }
         $current_level = strtolower( $context['membership_level'] );
         if ( 'premium' === $current_level ) {

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/class-tta-alert-bar.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/class-tta-alert-bar.php
@@ -21,15 +21,17 @@ class TTA_Alert_Bar {
             true
         );
 
+        $ban_info = tta_get_ban_message( get_current_user_id() );
         $data = [
-            'is_banned'      => tta_user_is_banned( get_current_user_id() ),
-            'reentry_url'    => add_query_arg( 'reentry', '1', home_url( '/checkout' ) ),
-            'checkout_url'   => home_url( '/checkout' ),
-            'banned_message' => __( 'You are banned due to excessive event no-shows or other reasons and must purchase a re-entry ticket to attend events again.', 'tta' ),
-            'reentry_label'  => __( 'Purchase Re-entry Ticket', 'tta' ),
-            'cart_message'   => __( 'Tickets reserved for', 'tta' ),
-            'checkout_label' => __( 'Go to Checkout', 'tta' ),
-            'cart_expires'   => 0,
+            'is_banned'     => tta_user_is_banned( get_current_user_id() ),
+            'reentry_url'   => add_query_arg( 'reentry', '1', home_url( '/checkout' ) ),
+            'checkout_url'  => home_url( '/checkout' ),
+            'banned_message'=> $ban_info['message'] ?? '',
+            'show_button'   => ! empty( $ban_info['button'] ),
+            'reentry_label' => __( 'Purchase Re-entry Ticket', 'tta' ),
+            'cart_message'  => __( 'Tickets reserved for', 'tta' ),
+            'checkout_label'=> __( 'Go to Checkout', 'tta' ),
+            'cart_expires'  => 0,
         ];
 
         if ( empty( $data['is_banned'] ) ) {

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/class-tta-member-dashboard.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/class-tta-member-dashboard.php
@@ -134,9 +134,12 @@ class TTA_Member_Dashboard {
           <?php if ( ! empty( $member['banned_until'] ) && strtotime( $member['banned_until'] ) > time() ) : ?>
             <div class="tta-banned-notice">
               <?php
-              $until_ts = strtotime( $member['banned_until'] );
-              $label    = $until_ts > strtotime( '2099-01-01' ) ? __( 'indefinitely', 'tta' ) : date_i18n( 'F j, Y', $until_ts );
-              printf( esc_html__( 'You are banned from making purchases until %s.', 'tta' ), esc_html( $label ) );
+              $ban = tta_get_ban_message( intval( $member['wpuserid'] ) );
+              echo wp_kses_post( $ban['message'] );
+              if ( ! empty( $ban['button'] ) ) {
+                  $url = add_query_arg( 'reentry', '1', home_url( '/checkout' ) );
+                  echo ' <a class="tta-alert-button" href="' . esc_url( $url ) . '">' . esc_html__( 'Purchase Re-entry Ticket', 'tta' ) . '</a>';
+              }
               ?>
             </div>
           <?php endif; ?>

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/templates/checkout-page-template.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/templates/checkout-page-template.php
@@ -203,7 +203,15 @@ if ( $checkout_done ) {
             <?php
             if ( $member_level ) {
                 if ( 'reentry' === $member_level ) {
-                    echo '<p>' . esc_html__( 'Thanks for purchasing a Re-Entry Ticket. Your account has been reinstated.', 'tta' ) . '</p>';
+                    printf(
+                        '<p>%s</p>',
+                        wp_kses_post(
+                            sprintf(
+                                __( 'Thanks for purchasing your Re-Entry Ticket! An email will be sent to %s with your purchase details. You\'re now able to purchase event tickets. Thanks again, and welcome back!', 'tta' ),
+                                esc_html( $user->user_email )
+                            )
+                        )
+                    );
                 } else {
                     $amount = 'premium' === $member_level ? TTA_PREMIUM_MEMBERSHIP_PRICE : TTA_BASIC_MEMBERSHIP_PRICE;
                     printf(

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/helpers.php
@@ -1512,6 +1512,31 @@ function tta_get_user_banned_until( $wp_user_id ) {
 }
 
 /**
+ * Get ban status info for a user.
+ *
+ * @param int $wp_user_id WordPress user ID.
+ * @return array { type:string, weeks:int }
+ */
+function tta_get_user_ban_status( $wp_user_id ) {
+    $until = tta_get_user_banned_until( $wp_user_id );
+    if ( ! $until ) {
+        return [ 'type' => 'none', 'weeks' => 0 ];
+    }
+    if ( TTA_BAN_UNTIL_INDEFINITE === $until ) {
+        return [ 'type' => 'indefinite', 'weeks' => 0 ];
+    }
+    if ( TTA_BAN_UNTIL_REENTRY === $until ) {
+        return [ 'type' => 'reentry', 'weeks' => 0 ];
+    }
+    $ts = strtotime( $until );
+    if ( ! $ts || $ts <= time() ) {
+        return [ 'type' => 'none', 'weeks' => 0 ];
+    }
+    $weeks = (int) ceil( ( $ts - time() ) / WEEK_IN_SECONDS );
+    return [ 'type' => 'timed', 'weeks' => max( 1, $weeks ) ];
+}
+
+/**
  * Determine if a user is currently banned.
  *
  * @param int $wp_user_id WordPress user ID.
@@ -1536,6 +1561,65 @@ function tta_unban_user( $wp_user_id ) {
     $table = $wpdb->prefix . 'tta_members';
     $wpdb->update( $table, [ 'banned_until' => null ], [ 'wpuserid' => intval( $wp_user_id ) ], [ '%s' ], [ '%d' ] );
     TTA_Cache::delete( 'banned_until_' . intval( $wp_user_id ) );
+    wp_clear_scheduled_hook( 'tta_reinstate_member', [ intval( $wp_user_id ) ] );
+}
+
+add_action( 'tta_reinstate_member', 'tta_unban_user', 10, 1 );
+
+/**
+ * Build a ban message and button flag for a user.
+ *
+ * @param int $wp_user_id WordPress user ID.
+ * @return array { message:string, button:bool }
+ */
+function tta_get_ban_message( $wp_user_id ) {
+    $status = tta_get_user_ban_status( $wp_user_id );
+    switch ( $status['type'] ) {
+        case 'indefinite':
+            return [
+                'message' => __( 'You are currently banned from purchasing tickets. Please use the <a href="/contact">contact form on our contact page</a> if you feel you\'ve been accidentally banned or would like to contest this.', 'tta' ),
+                'button'  => false,
+            ];
+        case 'reentry':
+            return [
+                'message' => __( 'You are banned due to excessive event no-shows or other reasons and must purchase a re-entry ticket to attend events again.', 'tta' ),
+                'button'  => true,
+            ];
+        case 'timed':
+            $w = intval( $status['weeks'] );
+            return [
+                'message' => sprintf( __( 'You are banned for %d week(s) due to excessive event no-shows or other reasons. After %d week(s), you will be automatically reinstated.  You may purchase a Re-entry Ticket to become reinstated early.', 'tta' ), $w, $w ),
+                'button'  => true,
+            ];
+    }
+    return [ 'message' => '', 'button' => false ];
+}
+
+/**
+ * Send the banned reinstatement email to a user.
+ *
+ * @param int $wp_user_id WordPress user ID.
+ */
+function tta_send_banned_reinstatement_email( $wp_user_id ) {
+    $templates = tta_get_comm_templates();
+    if ( empty( $templates['banned_reinstatement'] ) ) {
+        return;
+    }
+    $tpl     = $templates['banned_reinstatement'];
+    $context = tta_get_user_context_by_id( $wp_user_id );
+    $tokens  = [
+        '{first_name}' => $context['first_name'] ?? '',
+        '{email}'      => $context['user_email'] ?? '',
+    ];
+    $sub_raw = tta_expand_anchor_tokens( $tpl['email_subject'], $tokens );
+    $subject = tta_strip_bold( strtr( $sub_raw, $tokens ) );
+    $body_raw = tta_expand_anchor_tokens( $tpl['email_body'], $tokens );
+    $body_txt = tta_convert_bold( tta_convert_links( strtr( $body_raw, $tokens ) ) );
+    $body     = nl2br( $body_txt );
+    $to       = sanitize_email( $context['user_email'] );
+    if ( $to ) {
+        wp_mail( $to, $subject, $body, [ 'Content-Type: text/html; charset=UTF-8' ] );
+    }
 }
 
 /**

--- a/app/public/wp-content/plugins/tta-management-plugin/trying-to-adult-management-plugin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/trying-to-adult-management-plugin.php
@@ -27,6 +27,9 @@ define( 'TTA_BASIC_SUBSCRIPTION_NAME', 'Trying to Adult Basic Membership' );
 define( 'TTA_PREMIUM_SUBSCRIPTION_NAME', 'Trying to Adult Premium Membership' );
 define( 'TTA_BASIC_SUBSCRIPTION_DESCRIPTION', 'Monthly Basic Membership subscription for Trying to Adult.' );
 define( 'TTA_PREMIUM_SUBSCRIPTION_DESCRIPTION', 'Monthly Premium Membership subscription for Trying to Adult.' );
+// Ban sentinel datetimes
+define( 'TTA_BAN_UNTIL_INDEFINITE', '9999-12-31 23:59:59' );
+define( 'TTA_BAN_UNTIL_REENTRY', '9998-12-31 23:59:59' );
 
 if ( ! defined( 'TTA_AUTHNET_IMPORT_LOOKBACK_DAYS' ) ) {
     define( 'TTA_AUTHNET_IMPORT_LOOKBACK_DAYS', 93 );

--- a/docs/AlertBar.md
+++ b/docs/AlertBar.md
@@ -3,6 +3,6 @@
 The Alert Bar is a plugin-controlled element fixed to the bottom of the screen and injected into the DOM via JavaScript on every frontend page. It appears only in specific situations:
 
 1. **Tickets in Cart** – displays a countdown for the soonest expiring reservation and a button leading back to checkout.
-2. **Banned Member** – informs banned users they must purchase a $25 Re-Entry Ticket and links to the checkout page that automatically loads the ticket.
+2. **Banned Member** – displays messaging based on ban type. Indefinitely banned members are directed to the contact page, while re-entry and timed bans show a link that adds the Re-Entry Ticket to the cart. Timed bans also state the number of weeks remaining and note that purchasing the ticket lifts the ban early.
 
 Markup and assets are injected solely by the plugin and do not rely on theme templates.

--- a/docs/CartFlow.md
+++ b/docs/CartFlow.md
@@ -11,7 +11,7 @@ This document summarizes the current logic around the cart and checkout process 
    - Whenever a new item is added or a quantity increases, expired reservations are purged to free any leftover stock.
    - Expiration timestamps use WordPress local time so cleanup works consistently across servers.
   - Quantity selectors on the event page enforce each ticket's per‑member limit. Past purchases reduce the remaining allowance so members immediately see a notice if they already bought the maximum. The notice now clarifies when the limit is reached because of a previous transaction. Sold out ticket rows have their quantity controls disabled and the **Get Tickets** button is disabled if no tickets remain.
-   - When a user adds tickets, the browser issues an AJAX request to `tta_add_to_cart`. The handler calculates the price, reserves inventory, and calls `TTA_Cart::add_item()`.
+   - When a user adds tickets, the browser issues an AJAX request to `tta_add_to_cart`. The handler calculates the price, reserves inventory, and calls `TTA_Cart::add_item()`. If the request fails (for example, the member is banned), a modal overlay displays the error message and any HTML links remain clickable.
    - The AJAX handler now explicitly creates a cart row first via `ensure_cart_exists()` so empty databases start tracking sessions immediately.
    - Cart data is stored in the `tta_carts` and `tta_cart_items` tables keyed by a session ID. Ticket availability is decreased immediately on add and the related event cache is cleared.
 

--- a/docs/MemberDashboard.md
+++ b/docs/MemberDashboard.md
@@ -7,7 +7,7 @@ On screens narrower than 1200px the dashboard switches to a mobile-friendly layo
 
 When rendered the shortcode inserts a WPBakery hero banner above the dashboard using `do_shortcode()`. The banner displays **Member Dashboard** across a full-width background image.
 
-If a member is banned the dashboard displays a prominent notice at the top explaining the ban duration and purchases are blocked until it expires.
+If a member is banned the dashboard displays a prominent notice at the top. Indefinite bans simply state that purchases are blocked and direct members to the contact page, re-entry bans note that a Re-Entry Ticket is required, and timed bans show the reinstatement date or remaining weeks.
 Non-admin users never see the WordPress dashboard. On login the page simply reloads, and any attempt to access `/wp-admin/` redirects back to the front end.
 
 


### PR DESCRIPTION
## Summary
- add sentinel constants and helpers to determine ban type and messaging
- support re-entry bans, timed bans with cron reinstatement, and indefinite subscription cancellation
- show detailed ban notices with optional re-entry link and send reinstatement email

## Testing
- `composer install`
- `composer install` (plugin)
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68a20cc8b08c83208aeba69ac337bd17