### PR TITLE
Use site timezone for email reminders

### DIFF
--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-comms-admin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-comms-admin.php
@@ -360,10 +360,10 @@ class TTA_Comms_Admin {
                 echo '<td colspan="2"><div class="tta-inline-container">';
                 echo '<table class="widefat striped"><thead><tr><th>' . esc_html__( 'Type', 'tta' ) . '</th><th>' . esc_html__( 'Scheduled Time', 'tta' ) . '</th><th>' . esc_html__( 'Time Until', 'tta' ) . '</th><th>' . esc_html__( 'Actions', 'tta' ) . '</th></tr></thead><tbody>';
                 $tz  = wp_timezone();
-                $now = wp_date( 'U', TTA_Email_Reminders::current_time(), $tz );
+                $now = TTA_Email_Reminders::current_time();
                 foreach ( $info['jobs'] as $job ) {
-                    $send_ts = wp_date( 'U', $job['timestamp'], $tz );
-                    $time    = wp_date( 'm-d-Y g:iA', $job['timestamp'], $tz );
+                    $send_ts = $job['timestamp'];
+                    $time    = wp_date( 'm-d-Y g:iA', $send_ts, $tz );
                     $diff    = max( 0, $send_ts - $now );
                     $hours   = floor( $diff / HOUR_IN_SECONDS );
                     $minutes = floor( ( $diff % HOUR_IN_SECONDS ) / MINUTE_IN_SECONDS );

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/email/class-email-reminders.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/email/class-email-reminders.php
@@ -14,44 +14,22 @@ class TTA_Email_Reminders {
     }
 
     /**
-     * Retrieve cached offset between server time and real Eastern time.
-     *
-     * @return int Offset in seconds.
-     */
-    protected static function get_time_offset() {
-        $offset = get_transient( 'tta_time_offset' );
-        if ( false === $offset ) {
-            $offset  = 0;
-            $resp    = wp_remote_get( 'https://worldtimeapi.org/api/timezone/America/New_York' );
-            if ( ! is_wp_error( $resp ) ) {
-                $body      = json_decode( wp_remote_retrieve_body( $resp ), true );
-                $api_time  = intval( $body['unixtime'] ?? 0 );
-                if ( $api_time > 0 ) {
-                    $offset = $api_time - time();
-                }
-            }
-            set_transient( 'tta_time_offset', $offset, 5 * MINUTE_IN_SECONDS );
-        }
-        return intval( $offset );
-    }
-
-    /**
-     * Current real-world timestamp for Eastern time.
+     * Current UTC timestamp.
      *
      * @return int
      */
     public static function current_time() {
-        return time() + self::get_time_offset();
+        return current_time( 'timestamp', true );
     }
 
     /**
-     * Convert a real timestamp to server time for scheduling.
+     * Identity wrapper for clarity when scheduling with cron.
      *
-     * @param int $timestamp Real timestamp.
+     * @param int $timestamp UTC timestamp.
      * @return int
      */
     protected static function to_server_time( $timestamp ) {
-        return $timestamp - self::get_time_offset();
+        return $timestamp;
     }
 
     /**
@@ -148,7 +126,6 @@ class TTA_Email_Reminders {
             'tta_post_event_thanks_email',
         ];
         $scheduled = [];
-        $offset    = self::get_time_offset();
         foreach ( $cron as $timestamp => $events ) {
             foreach ( $events as $hook => $jobs ) {
                 if ( ! in_array( $hook, $hooks, true ) ) {
@@ -184,7 +161,7 @@ class TTA_Email_Reminders {
                     $scheduled[ $event_id ]['jobs'][] = [
                         'hook'      => $hook,
                         'template'  => $template,
-                        'timestamp' => $timestamp + $offset,
+                        'timestamp' => $timestamp,
                         'label'     => $label,
                     ];
                 }

--- a/app/public/wp-content/plugins/tta-management-plugin/tests/EmailReminderScheduleTest.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/tests/EmailReminderScheduleTest.php
@@ -110,7 +110,8 @@ class EmailReminderScheduleTest extends TestCase {
         $this->assertSame( $expected, $timestamp );
     }
 
-    public function test_schedule_adjusts_for_server_offset() {
+    public function test_schedule_ignores_time_offset_transient() {
+        // Simulate an offset transient which should now be ignored.
         $GLOBALS['transients'] = [ 'tta_time_offset' => -4 * HOUR_IN_SECONDS ];
         require_once __DIR__ . '/../includes/email/class-email-reminders.php';
         TTA_Email_Reminders::schedule_event_emails( 1 );
@@ -122,8 +123,8 @@ class EmailReminderScheduleTest extends TestCase {
             }
         }
         $this->assertNotNull( $timestamp );
-        $real = ( new DateTime( '2030-08-14 18:00', wp_timezone() ) )->setTimezone( new DateTimeZone( 'UTC' ) )->getTimestamp();
-        $this->assertSame( $real + 4 * HOUR_IN_SECONDS, $timestamp );
+        $expected = ( new DateTime( '2030-08-14 18:00', wp_timezone() ) )->setTimezone( new DateTimeZone( 'UTC' ) )->getTimestamp();
+        $this->assertSame( $expected, $timestamp );
     }
 
     public function test_schedule_post_event_thanks_creates_event() {

--- a/docs/EmailSMS.md
+++ b/docs/EmailSMS.md
@@ -3,7 +3,7 @@
 The plugin sends automated notifications to members. Administrators can manage these messages from **TTA Email & SMS** in the WordPress admin. The page contains three tabs:
 
 1. **Email Templates** – existing template editor described below.
-2. **Email Logs** – lists scheduled reminder and thank‑you emails grouped by event. Reminder jobs are automatically queued whenever an event is created or its start time changes and are scheduled using the site's timezone setting. To guard against misconfigured server clocks, the plugin fetches the current Eastern time from `worldtimeapi.org` and caches the offset for five minutes. Each entry shows the send time in `MM-DD-YYYY HH:MMAM/PM` format along with a live `HH H, MM M, SS S` countdown that now calculates using the site's timezone for accurate remaining time, exposes its current recipient list via AJAX, and can be deleted before it runs.
+2. **Email Logs** – lists scheduled reminder and thank‑you emails grouped by event. Reminder jobs are automatically queued whenever an event is created or its start time changes and are scheduled using the site's timezone setting. Each entry shows the send time in `MM-DD-YYYY HH:MMAM/PM` format along with a live `HH H, MM M, SS S` countdown using the site's timezone, exposes its current recipient list via AJAX, and can be deleted before it runs.
 3. **Email History** – a running log of all attempted emails including recipient address and delivery result. A **Clear Log** button removes all entries.
 
 Templates are listed in a table similar to the Manage Events page. Click a row to expand an inline form containing the fields for that communication. Each form has its own **Save Changes** button and progress spinner.


### PR DESCRIPTION
## Summary
- remove external time offset and rely on WordPress timezone for cron scheduling
- adjust admin log countdown to compute from UTC timestamps
- document new approach and update tests

## Testing
- `sudo apt-get update`
- `sudo apt-get install -y php`
- `composer install`
- `composer install` (plugin)
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68a2e7dff5308320839688efc5ff3f57