### PR TITLE
Show login forms on member dashboard for guests

### DIFF
--- a/app/public/wp-content/plugins/tta-management-plugin/assets/css/frontend/member-dashboard.css
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/css/frontend/member-dashboard.css
@@ -371,7 +371,7 @@
   height: 35px;
 }
 
-#tta-update-card-form > p.tta-submit-wrap{
+#tta-update-card-form > .tta-submit-wrap{
   display:block;
 }
 

--- a/app/public/wp-content/plugins/tta-management-plugin/assets/css/frontend/member-dashboard.css
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/css/frontend/member-dashboard.css
@@ -6,6 +6,34 @@
       display: block;
 }
 
+/* Login message styles */
+.tta-message-center {
+  background: #faf8e5;
+  border: 1px solid #f0e0b0;
+  border-radius: 4px;
+  padding: 15px 20px;
+  margin: 20px 0;
+}
+.tta-login-accordion .tta-accordion-content {
+  max-height: 0;
+  overflow: hidden;
+  padding: 0;
+  transition: max-height 0.4s ease, padding 0.4s ease;
+}
+.tta-login-accordion .tta-accordion-content.expanded {
+  max-height: 400px;
+  padding: 20px 0 0;
+  background: #faf8e5;
+}
+.tta-button-link {
+  background: none;
+  border: none;
+  padding: 0;
+  color: #0073aa;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
 /* Show Profile tab on load */
 #tab-profile { display: block; }
 

--- a/app/public/wp-content/plugins/tta-management-plugin/assets/css/frontend/member-dashboard.css
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/css/frontend/member-dashboard.css
@@ -25,6 +25,14 @@
   padding: 20px 0 0;
   background: #faf8e5;
 }
+.tta-login-accordion .tta-button {
+  display: inline-block;
+  padding: 10px 20px;
+  background: #0073aa;
+  color: #fff;
+  text-decoration: none;
+  border-radius: 4px;
+}
 .tta-button-link {
   background: none;
   border: none;

--- a/app/public/wp-content/plugins/tta-management-plugin/assets/js/frontend/member-dashboard.js
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/js/frontend/member-dashboard.js
@@ -448,4 +448,89 @@ jQuery(function($){
       }, delay);
     });
   });
+
+  // Login/register handling for guests
+  $('.tta-login-message').on('click', '.tta-show-register', function(e){
+    e.preventDefault();
+    var $section = $(this).closest('.tta-login-message');
+    var $link = $(this);
+    $link.addClass('tta-button-disabled').attr('aria-disabled', 'true').attr('tabindex', '-1');
+    $section.find('.tta-login-wrap').fadeOut(200, function(){
+      $section.find('.tta-register-form').fadeIn(200);
+    });
+  });
+
+  $('.tta-login-message').on('click', '.tta-cancel-register', function(e){
+    e.preventDefault();
+    var $section = $(this).closest('.tta-login-message');
+    $section.find('.tta-register-form').fadeOut(200, function(){
+      $section.find('.tta-login-wrap').fadeIn(200);
+    });
+    var $link = $section.find('.tta-show-register');
+    $link.removeClass('tta-button-disabled').removeAttr('aria-disabled tabindex');
+  });
+
+  $('.tta-login-message').on('submit', '.tta-register-form', function(e){
+    e.preventDefault();
+    e.stopPropagation();
+    var $form = $(this),
+        $section = $form.closest('.tta-login-message'),
+        $btn  = $form.find('button'),
+        $spin = $form.find('.tta-admin-progress-spinner-svg'),
+        $resp = $section.find('.tta-register-response'),
+        email = $form.find('[name="email"]').val(),
+        emailVerify = $form.find('[name="email_verify"]').val(),
+        pass  = $form.find('[name="password"]').val(),
+        passVerify = $form.find('[name="password_verify"]').val();
+
+    $resp.removeClass('updated error').text('');
+
+    if(email !== emailVerify){
+      $resp.addClass('error').text(TTA_MemberDashboard.email_mismatch_msg);
+      return;
+    }
+    if(pass !== passVerify){
+      $resp.addClass('error').text(TTA_MemberDashboard.password_mismatch_msg);
+      return;
+    }
+    if(!/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).{8,}$/.test(pass)){
+      $resp.addClass('error').text(TTA_MemberDashboard.password_requirements_msg);
+      return;
+    }
+
+    $btn.prop('disabled', true);
+    $spin.show().css({opacity:0}).fadeTo(200,1);
+
+    $.post(TTA_MemberDashboard.ajax_url, {
+      action: 'tta_register',
+      nonce: TTA_MemberDashboard.front_nonce,
+      first_name: $form.find('[name="first_name"]').val(),
+      last_name:  $form.find('[name="last_name"]').val(),
+      email:      email,
+      email_verify: emailVerify,
+      password:   pass,
+      password_verify: passVerify
+    }, function(res){
+      $spin.fadeOut(200);
+      if(res.success){
+        var count = 5;
+        (function update(){
+          $resp.removeClass('error').addClass('updated')
+               .text(TTA_MemberDashboard.account_created_msg.replace('%d', count));
+          if(count-- > 0){
+            setTimeout(update, 1000);
+          } else {
+            window.location.reload();
+          }
+        })();
+      } else {
+        $btn.prop('disabled', false);
+        $resp.addClass('error').text(res.data.message || TTA_MemberDashboard.request_failed_msg);
+      }
+    }, 'json').fail(function(){
+      $spin.fadeOut(200);
+      $btn.prop('disabled', false);
+      $resp.addClass('error').text(TTA_MemberDashboard.request_failed_msg);
+    });
+  });
 });

--- a/app/public/wp-content/plugins/tta-management-plugin/assets/js/frontend/member-dashboard.js
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/js/frontend/member-dashboard.js
@@ -133,6 +133,91 @@ jQuery(function($){
     this.value = v;
   });
 
+  // Login/register handling for guests
+  $('.tta-login-message').on('click', '.tta-show-register', function(e){
+    e.preventDefault();
+    var $section = $(this).closest('.tta-login-message');
+    var $link = $(this);
+    $link.addClass('tta-button-disabled').attr('aria-disabled', 'true').attr('tabindex', '-1');
+    $section.find('.tta-login-wrap').fadeOut(200, function(){
+      $section.find('.tta-register-form').fadeIn(200);
+    });
+  });
+
+  $('.tta-login-message').on('click', '.tta-cancel-register', function(e){
+    e.preventDefault();
+    var $section = $(this).closest('.tta-login-message');
+    $section.find('.tta-register-form').fadeOut(200, function(){
+      $section.find('.tta-login-wrap').fadeIn(200);
+    });
+    var $link = $section.find('.tta-show-register');
+    $link.removeClass('tta-button-disabled').removeAttr('aria-disabled tabindex');
+  });
+
+  $('.tta-login-message').on('submit', '.tta-register-form', function(e){
+    e.preventDefault();
+    e.stopPropagation();
+    var $form = $(this),
+        $section = $form.closest('.tta-login-message'),
+        $btn  = $form.find('button'),
+        $spin = $form.find('.tta-admin-progress-spinner-svg'),
+        $resp = $section.find('.tta-register-response'),
+        email = $form.find('[name="email"]').val(),
+        emailVerify = $form.find('[name="email_verify"]').val(),
+        pass  = $form.find('[name="password"]').val(),
+        passVerify = $form.find('[name="password_verify"]').val();
+
+    $resp.removeClass('updated error').text('');
+
+    if(email !== emailVerify){
+      $resp.addClass('error').text(TTA_MemberDashboard.email_mismatch_msg);
+      return;
+    }
+    if(pass !== passVerify){
+      $resp.addClass('error').text(TTA_MemberDashboard.password_mismatch_msg);
+      return;
+    }
+    if(!/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).{8,}$/.test(pass)){
+      $resp.addClass('error').text(TTA_MemberDashboard.password_requirements_msg);
+      return;
+    }
+
+    $btn.prop('disabled', true);
+    $spin.show().css({opacity:0}).fadeTo(200,1);
+
+    $.post(TTA_MemberDashboard.ajax_url, {
+      action: 'tta_register',
+      nonce: TTA_MemberDashboard.front_nonce,
+      first_name: $form.find('[name="first_name"]').val(),
+      last_name:  $form.find('[name="last_name"]').val(),
+      email:      email,
+      email_verify: emailVerify,
+      password:   pass,
+      password_verify: passVerify
+    }, function(res){
+      $spin.fadeOut(200);
+      if(res.success){
+        var count = 5;
+        (function update(){
+          $resp.removeClass('error').addClass('updated')
+               .text(TTA_MemberDashboard.account_created_msg.replace('%d', count));
+          if(count-- > 0){
+            setTimeout(update, 1000);
+          } else {
+            window.location.reload();
+          }
+        })();
+      } else {
+        $btn.prop('disabled', false);
+        $resp.addClass('error').text(res.data.message || TTA_MemberDashboard.request_failed_msg);
+      }
+    }, 'json').fail(function(){
+      $spin.fadeOut(200);
+      $btn.prop('disabled', false);
+      $resp.addClass('error').text(TTA_MemberDashboard.request_failed_msg);
+    });
+  });
+
   if ( !$form.length ) return;
 
   // 5) File picker & preview
@@ -449,88 +534,4 @@ jQuery(function($){
     });
   });
 
-  // Login/register handling for guests
-  $('.tta-login-message').on('click', '.tta-show-register', function(e){
-    e.preventDefault();
-    var $section = $(this).closest('.tta-login-message');
-    var $link = $(this);
-    $link.addClass('tta-button-disabled').attr('aria-disabled', 'true').attr('tabindex', '-1');
-    $section.find('.tta-login-wrap').fadeOut(200, function(){
-      $section.find('.tta-register-form').fadeIn(200);
-    });
-  });
-
-  $('.tta-login-message').on('click', '.tta-cancel-register', function(e){
-    e.preventDefault();
-    var $section = $(this).closest('.tta-login-message');
-    $section.find('.tta-register-form').fadeOut(200, function(){
-      $section.find('.tta-login-wrap').fadeIn(200);
-    });
-    var $link = $section.find('.tta-show-register');
-    $link.removeClass('tta-button-disabled').removeAttr('aria-disabled tabindex');
-  });
-
-  $('.tta-login-message').on('submit', '.tta-register-form', function(e){
-    e.preventDefault();
-    e.stopPropagation();
-    var $form = $(this),
-        $section = $form.closest('.tta-login-message'),
-        $btn  = $form.find('button'),
-        $spin = $form.find('.tta-admin-progress-spinner-svg'),
-        $resp = $section.find('.tta-register-response'),
-        email = $form.find('[name="email"]').val(),
-        emailVerify = $form.find('[name="email_verify"]').val(),
-        pass  = $form.find('[name="password"]').val(),
-        passVerify = $form.find('[name="password_verify"]').val();
-
-    $resp.removeClass('updated error').text('');
-
-    if(email !== emailVerify){
-      $resp.addClass('error').text(TTA_MemberDashboard.email_mismatch_msg);
-      return;
-    }
-    if(pass !== passVerify){
-      $resp.addClass('error').text(TTA_MemberDashboard.password_mismatch_msg);
-      return;
-    }
-    if(!/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).{8,}$/.test(pass)){
-      $resp.addClass('error').text(TTA_MemberDashboard.password_requirements_msg);
-      return;
-    }
-
-    $btn.prop('disabled', true);
-    $spin.show().css({opacity:0}).fadeTo(200,1);
-
-    $.post(TTA_MemberDashboard.ajax_url, {
-      action: 'tta_register',
-      nonce: TTA_MemberDashboard.front_nonce,
-      first_name: $form.find('[name="first_name"]').val(),
-      last_name:  $form.find('[name="last_name"]').val(),
-      email:      email,
-      email_verify: emailVerify,
-      password:   pass,
-      password_verify: passVerify
-    }, function(res){
-      $spin.fadeOut(200);
-      if(res.success){
-        var count = 5;
-        (function update(){
-          $resp.removeClass('error').addClass('updated')
-               .text(TTA_MemberDashboard.account_created_msg.replace('%d', count));
-          if(count-- > 0){
-            setTimeout(update, 1000);
-          } else {
-            window.location.reload();
-          }
-        })();
-      } else {
-        $btn.prop('disabled', false);
-        $resp.addClass('error').text(res.data.message || TTA_MemberDashboard.request_failed_msg);
-      }
-    }, 'json').fail(function(){
-      $spin.fadeOut(200);
-      $btn.prop('disabled', false);
-      $resp.addClass('error').text(TTA_MemberDashboard.request_failed_msg);
-    });
-  });
 });

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/class-tta-member-dashboard.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/class-tta-member-dashboard.php
@@ -72,10 +72,15 @@ class TTA_Member_Dashboard {
                 'tta-member-dashboard-js',
                 'TTA_MemberDashboard',
                 [
-                    'ajax_url'     => admin_url( 'admin-ajax.php' ),
-                    'update_nonce' => wp_create_nonce( 'tta_member_front_update' ),
-                    'front_nonce'  => wp_create_nonce( 'tta_frontend_nonce' ),
-                    'plugin_url'   => TTA_PLUGIN_URL,
+                    'ajax_url'                 => admin_url( 'admin-ajax.php' ),
+                    'update_nonce'             => wp_create_nonce( 'tta_member_front_update' ),
+                    'front_nonce'              => wp_create_nonce( 'tta_frontend_nonce' ),
+                    'plugin_url'               => TTA_PLUGIN_URL,
+                    'email_mismatch_msg'       => __( 'Email addresses do not match.', 'tta' ),
+                    'password_mismatch_msg'    => __( 'Passwords do not match.', 'tta' ),
+                    'password_requirements_msg'=> __( 'Password must be at least 8 characters and include upper and lower case letters and a number.', 'tta' ),
+                    'request_failed_msg'       => __( 'Request failed.', 'tta' ),
+                    'account_created_msg'      => __( 'Account created! Reloading in %d…', 'tta' ),
                 ]
             );
         }
@@ -85,63 +90,61 @@ class TTA_Member_Dashboard {
      * Shortcode callback: renders the member dashboard.
      */
     public function render_dashboard_shortcode( $atts ) {
-        if ( ! is_user_logged_in() ) {
-            ob_start();
-            echo do_shortcode('[vc_row full_width="stretch_row_content_no_spaces" css=".vc_custom_1670382516702{background-image: url(https://trying-to-adult-rva-2025.local/wp-content/uploads/2022/12/IMG-4418.png?id=70) !important;background-position: center !important;background-repeat: no-repeat !important;background-size: cover !important;}"][vc_column][vc_empty_space height="300px" el_id="jre-header-title-empty"][vc_column_text css_animation="slideInLeft" el_id="jre-homepage-id-1" css=".vc_custom_1671885403487{margin-left: 50px !important;padding-left: 50px !important;}"]<p id="jre-homepage-id-3">MEMBER DASHBOARD</p>[/vc_column_text][/vc_column][/vc_row]');
-            wp_login_form([
-                'redirect'       => get_permalink(),
-                'label_username' => __( 'Username or Email' ),
-                'label_password' => __( 'Password' ),
-                'remember'       => true,
-            ]);
-            return ob_get_clean();
-        }
+        $is_logged_in = is_user_logged_in();
+        $member       = null;
 
-        // Fetch member record
-        $wp_user_id    = get_current_user_id();
-        global $wpdb;
-        $members_table = $wpdb->prefix . 'tta_members';
+        if ( $is_logged_in ) {
+            // Fetch member record
+            $wp_user_id    = get_current_user_id();
+            global $wpdb;
+            $members_table = $wpdb->prefix . 'tta_members';
 
-        $member = $wpdb->get_row(
-            $wpdb->prepare( "SELECT * FROM {$members_table} WHERE wpuserid = %d LIMIT 1", $wp_user_id ),
-            ARRAY_A
-        );
-        if ( ! $member ) {
-            return '<p>' . esc_html__( 'No member record found.', 'tta' ) . '</p>';
-        }
+            $member = $wpdb->get_row(
+                $wpdb->prepare( "SELECT * FROM {$members_table} WHERE wpuserid = %d LIMIT 1", $wp_user_id ),
+                ARRAY_A
+            );
+            if ( ! $member ) {
+                return '<p>' . esc_html__( 'No member record found.', 'tta' ) . '</p>';
+            }
 
-        // Split address into parts
-        $street_address = '';
-        $address_2      = '';
-        $city           = '';
-        $state          = '';
-        $zip            = '';
-        if ( ! empty( $member['address'] ) ) {
-            $addr            = tta_parse_address( $member['address'] );
-            $street_address  = $addr['street'];
-            $address_2       = $addr['address2'];
-            $city            = $addr['city'];
-            $state           = $addr['state'];
-            $zip             = $addr['zip'];
+            // Split address into parts
+            $street_address = '';
+            $address_2      = '';
+            $city           = '';
+            $state          = '';
+            $zip            = '';
+            if ( ! empty( $member['address'] ) ) {
+                $addr            = tta_parse_address( $member['address'] );
+                $street_address  = $addr['street'];
+                $address_2       = $addr['address2'];
+                $city            = $addr['city'];
+                $state           = $addr['state'];
+                $zip             = $addr['zip'];
+            }
         }
 
         ob_start();
         echo do_shortcode('[vc_row full_width="stretch_row_content_no_spaces" css=".vc_custom_1670382516702{background-image: url(https://trying-to-adult-rva-2025.local/wp-content/uploads/2022/12/IMG-4418.png?id=70) !important;background-position: center !important;background-repeat: no-repeat !important;background-size: cover !important;}"][vc_column][vc_empty_space height="300px" el_id="jre-header-title-empty"][vc_column_text css_animation="slideInLeft" el_id="jre-homepage-id-1" css=".vc_custom_1671885403487{margin-left: 50px !important;padding-left: 50px !important;}"]<p id="jre-homepage-id-3">MEMBER DASHBOARD</p>[/vc_column_text][/vc_column][/vc_row]');
         ?>
         <div class="tta-member-dashboard-wrap">
-          <h2><?php echo esc_html( 'Welcome, ' . $member['first_name'] . '!' ); ?></h2>
-          <p><?php echo esc_html( 'A Member since ' . date_i18n( 'F j, Y', strtotime( $member['joined_at'] ) ) ); ?></p>
-          <?php if ( ! empty( $member['banned_until'] ) && strtotime( $member['banned_until'] ) > time() ) : ?>
-            <div class="tta-banned-notice">
-              <?php
-              $ban = tta_get_ban_message( intval( $member['wpuserid'] ) );
-              echo wp_kses_post( $ban['message'] );
-              if ( ! empty( $ban['button'] ) ) {
-                  $url = add_query_arg( 'reentry', '1', home_url( '/checkout' ) );
-                  echo ' <a class="tta-alert-button" href="' . esc_url( $url ) . '">' . esc_html__( 'Purchase Re-entry Ticket', 'tta' ) . '</a>';
-              }
-              ?>
-            </div>
+          <?php if ( $is_logged_in ) : ?>
+            <h2><?php echo esc_html( 'Welcome, ' . $member['first_name'] . '!' ); ?></h2>
+            <p><?php echo esc_html( 'A Member since ' . date_i18n( 'F j, Y', strtotime( $member['joined_at'] ) ) ); ?></p>
+            <?php if ( ! empty( $member['banned_until'] ) && strtotime( $member['banned_until'] ) > time() ) : ?>
+              <div class="tta-banned-notice">
+                <?php
+                $ban = tta_get_ban_message( intval( $member['wpuserid'] ) );
+                echo wp_kses_post( $ban['message'] );
+                if ( ! empty( $ban['button'] ) ) {
+                    $url = add_query_arg( 'reentry', '1', home_url( '/checkout' ) );
+                    echo ' <a class="tta-alert-button" href="' . esc_url( $url ) . '">' . esc_html__( 'Purchase Re-entry Ticket', 'tta' ) . '</a>';
+                }
+                ?>
+              </div>
+            <?php endif; ?>
+          <?php else : ?>
+            <h2><?php esc_html_e( 'Welcome!', 'tta' ); ?></h2>
+            <p><?php esc_html_e( 'Log in to view your member information.', 'tta' ); ?></p>
           <?php endif; ?>
 
           <div class="tta-member-dashboard">
@@ -156,16 +159,24 @@ class TTA_Member_Dashboard {
             </div>
 
             <div class="tta-dashboard-content">
-              
-              <?php include plugin_dir_path( __FILE__ ) . 'views/tab-profile.php'; ?>
 
-              <?php include plugin_dir_path( __FILE__ ) . 'views/tab-upcoming.php'; ?>
+              <?php if ( $is_logged_in ) : ?>
+                <?php include plugin_dir_path( __FILE__ ) . 'views/tab-profile.php'; ?>
 
-              <?php include plugin_dir_path( __FILE__ ) . 'views/tab-waitlist.php'; ?>
+                <?php include plugin_dir_path( __FILE__ ) . 'views/tab-upcoming.php'; ?>
 
-              <?php include plugin_dir_path( __FILE__ ) . 'views/tab-past-events.php'; ?>
+                <?php include plugin_dir_path( __FILE__ ) . 'views/tab-waitlist.php'; ?>
 
-              <?php include plugin_dir_path( __FILE__ ) . 'views/tab-billing.php'; ?>
+                <?php include plugin_dir_path( __FILE__ ) . 'views/tab-past-events.php'; ?>
+
+                <?php include plugin_dir_path( __FILE__ ) . 'views/tab-billing.php'; ?>
+              <?php else : ?>
+                <?php $tab_slug = 'profile';  include plugin_dir_path( __FILE__ ) . 'views/tab-login.php'; ?>
+                <?php $tab_slug = 'upcoming'; include plugin_dir_path( __FILE__ ) . 'views/tab-login.php'; ?>
+                <?php $tab_slug = 'waitlist'; include plugin_dir_path( __FILE__ ) . 'views/tab-login.php'; ?>
+                <?php $tab_slug = 'past';     include plugin_dir_path( __FILE__ ) . 'views/tab-login.php'; ?>
+                <?php $tab_slug = 'billing';  include plugin_dir_path( __FILE__ ) . 'views/tab-login.php'; ?>
+              <?php endif; ?>
 
             </div>
           </div>
@@ -173,6 +184,7 @@ class TTA_Member_Dashboard {
         <?php
         return ob_get_clean();
     }
+
 }
 
 TTA_Member_Dashboard::get_instance();

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/views/tab-billing.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/views/tab-billing.php
@@ -119,13 +119,13 @@
               <input type="text" name="bill_zip" value="<?php echo esc_attr( $zip ); ?>" required />
             </label>
           </p>
-          <p class="tta-submit-wrap">
+          <div class="tta-submit-wrap">
             <button type="submit" class="button"><?php esc_html_e( 'Update Payment Method', 'tta' ); ?></button>
             <span class="tta-progress-spinner">
               <img class="tta-admin-progress-spinner-svg" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/loading.svg' ); ?>" alt="<?php esc_attr_e( 'Loading…', 'tta' ); ?>" />
             </span>
-            <span class="tta-admin-progress-response"><p class="tta-admin-progress-response-p"></p></span>
-          </p>
+            <span class="tta-admin-progress-response-p"></span>
+          </div>
         </form>
       <?php endif; ?>
   <?php else :
@@ -144,15 +144,15 @@
       <form id="tta-cancel-membership-form" method="post" action="<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>">
         <?php wp_nonce_field( 'tta_member_front_update', 'nonce' ); ?>
         <input type="hidden" name="action" value="tta_cancel_membership" />
-        <p class="tta-submit-wrap">
+        <div class="tta-submit-wrap">
           <button type="submit" class="button">
             <?php esc_html_e( 'Cancel Membership', 'tta' ); ?>
           </button>
           <span class="tta-progress-spinner">
             <img class="tta-admin-progress-spinner-svg" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/loading.svg' ); ?>" alt="<?php esc_attr_e( 'Loading…', 'tta' ); ?>" />
           </span>
-          <span class="tta-admin-progress-response"><p class="tta-admin-progress-response-p"></p></span>
-        </p>
+          <span class="tta-admin-progress-response-p"></span>
+        </div>
       </form>
       <h4><?php esc_html_e( 'Update Payment Method', 'tta' ); ?></h4>
       <form id="tta-update-card-form" method="post" action="<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>" class="tta-update-card-form">
@@ -222,13 +222,13 @@
             <input type="text" name="bill_zip" value="<?php echo esc_attr( $zip ); ?>" required />
           </label>
         </p>
-        <p class="tta-submit-wrap">
+        <div class="tta-submit-wrap">
           <button type="submit" class="button"><?php esc_html_e( 'Update Payment Method', 'tta' ); ?></button>
           <span class="tta-progress-spinner">
             <img class="tta-admin-progress-spinner-svg" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/loading.svg' ); ?>" alt="<?php esc_attr_e( 'Loading…', 'tta' ); ?>" />
           </span>
-          <span class="tta-admin-progress-response"><p class="tta-admin-progress-response-p"></p></span>
-        </p>
+          <span class="tta-admin-progress-response-p"></span>
+        </div>
       </form>
     <?php endif; ?>
   <?php endif; ?>

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/views/tab-login.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/views/tab-login.php
@@ -1,0 +1,75 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+$tab_slug = isset( $tab_slug ) ? $tab_slug : 'profile';
+$form_id  = 'loginform-' . $tab_slug;
+$form_html = wp_login_form(
+    [
+        'echo'     => false,
+        'redirect' => home_url( '/member-dashboard/?tab=' . $tab_slug ),
+        'form_id'  => $form_id,
+    ]
+);
+$lost_pw_url = wp_lostpassword_url( home_url( '/member-dashboard/?tab=' . $tab_slug ) );
+?>
+<div id="tab-<?php echo esc_attr( $tab_slug ); ?>" class="tta-dashboard-section">
+  <section class="tta-message-center tta-login-accordion tta-login-message">
+    <h2><?php esc_html_e( 'Log in or Register Here', 'tta' ); ?></h2>
+    <div class="tta-accordion">
+      <p>
+        <?php
+        printf(
+            esc_html__( 'Ticket discounts may be available! Log in below to check. Don\'t have an account? Create one below or become a Member today!%s', 'tta' ),
+            '<div><a href="#" class="tta-button tta-button-primary tta-show-register">' . esc_html__( 'Create Account', 'tta' ) . '</a><a href="/become-a-member" class="tta-button tta-button-primary">' . esc_html__( 'Become a Member', 'tta' ) . '</a></div>'
+        );
+        ?>
+      </p>
+      <div class="tta-accordion-content expanded">
+        <div class="tta-login-wrap">
+          <?php echo $form_html; ?>
+          <p class="login-lost-password"><a href="<?php echo esc_url( $lost_pw_url ); ?>"><?php esc_html_e( 'Forgot your password?', 'tta' ); ?></a></p>
+        </div>
+        <form class="tta-register-form" style="display:none;">
+          <p>
+            <label><?php esc_html_e( 'First Name', 'tta' ); ?><br />
+              <input type="text" name="first_name" required />
+            </label>
+          </p>
+          <p>
+            <label><?php esc_html_e( 'Last Name', 'tta' ); ?><br />
+              <input type="text" name="last_name" required />
+            </label>
+          </p>
+          <p>
+            <label><?php esc_html_e( 'Email', 'tta' ); ?><br />
+              <input type="email" name="email" required />
+            </label>
+          </p>
+          <p>
+            <label><?php esc_html_e( 'Verify Email', 'tta' ); ?><br />
+              <input type="email" name="email_verify" required />
+            </label>
+          </p>
+          <p>
+            <label><?php esc_html_e( 'Password', 'tta' ); ?><br />
+              <input type="password" name="password" required />
+            </label>
+          </p>
+          <p>
+            <label><?php esc_html_e( 'Verify Password', 'tta' ); ?><br />
+              <input type="password" name="password_verify" required />
+            </label>
+          </p>
+          <p>
+            <button type="submit" class="tta-button tta-button-primary"><?php esc_html_e( 'Create Account', 'tta' ); ?></button>
+            <a href="#" class="tta-button-link tta-cancel-register"><?php esc_html_e( 'Cancel Account Creation', 'tta' ); ?></a>
+            <img class="tta-admin-progress-spinner-svg" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/loading.svg' ); ?>" alt="<?php esc_attr_e( 'Loading…', 'tta' ); ?>" />
+          </p>
+          <span class="tta-register-response tta-admin-progress-response-p"></span>
+        </form>
+      </div>
+    </div>
+  </section>
+</div>

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/views/tab-login.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/views/tab-login.php
@@ -18,14 +18,15 @@ $lost_pw_url = wp_lostpassword_url( home_url( '/member-dashboard/?tab=' . $tab_s
   <section class="tta-message-center tta-login-accordion tta-login-message">
     <h2><?php esc_html_e( 'Log in or Register Here', 'tta' ); ?></h2>
     <div class="tta-accordion">
-      <p>
-        <?php
-        printf(
-            esc_html__( 'Ticket discounts may be available! Log in below to check. Don\'t have an account? Create one below or become a Member today!%s', 'tta' ),
-            '<div><a href="#" class="tta-button tta-button-primary tta-show-register">' . esc_html__( 'Create Account', 'tta' ) . '</a><a href="/become-a-member" class="tta-button tta-button-primary">' . esc_html__( 'Become a Member', 'tta' ) . '</a></div>'
-        );
-        ?>
-      </p>
+        <p>
+          <?php
+          printf(
+              /* translators: 1: action buttons */
+              esc_html__( 'Join today to create your profile, view your upcoming & past events, and more! Create a free account below or become a Member today!%1$s', 'tta' ),
+              '<div><a href="#" class="tta-button tta-button-primary tta-show-register">' . esc_html__( 'Create Account', 'tta' ) . '</a><a href="/become-a-member" class="tta-button tta-button-primary">' . esc_html__( 'Become a Member', 'tta' ) . '</a></div>'
+          );
+          ?>
+        </p>
       <div class="tta-accordion-content expanded">
         <div class="tta-login-wrap">
           <?php echo $form_html; ?>

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/views/tab-past-events.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/views/tab-past-events.php
@@ -108,8 +108,8 @@
               <?php endforeach; ?>
               </ul>
             </div>
-          </div>
           <?php endforeach; ?>
+        </div>
       <?php endforeach; ?>
   <?php else : ?>
       <p><?php esc_html_e( 'No past events found.', 'tta' ); ?></p>

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/views/tab-profile.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/views/tab-profile.php
@@ -456,7 +456,7 @@ $hide_attendance = intval( $member['hide_event_attendance'] );
       </tbody>
     </table>
 
-    <p class="tta-submit-wrap">
+    <div class="tta-submit-wrap">
       <button type="button" id="toggle-edit-mode" class="button">
         <?php esc_html_e( 'Edit Profile', 'tta' ); ?>
       </button>
@@ -468,10 +468,8 @@ $hide_attendance = intval( $member['hide_event_attendance'] );
              src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/loading.svg' ); ?>"
              alt="<?php esc_attr_e( 'Loading…', 'tta' ); ?>" />
       </span>
-      <span class="tta-admin-progress-response">
-        <p class="tta-admin-progress-response-p"></p>
-      </span>
-    </p>
+      <span class="tta-admin-progress-response-p"></span>
+    </div>
 
   </form>
 </div>

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/views/tab-upcoming.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/views/tab-upcoming.php
@@ -119,7 +119,7 @@
                   <span class="tta-progress-spinner">
                     <img class="tta-admin-progress-spinner-svg" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/loading.svg' ); ?>" alt="<?php esc_attr_e( 'Loading…', 'tta' ); ?>" />
                   </span>
-                  <span class="tta-admin-progress-response"><p class="tta-admin-progress-response-p"></p></span>
+                  <span class="tta-admin-progress-response-p"></span>
                 </form>
               </div>
               <?php endif; ?>
@@ -134,7 +134,7 @@
             <span class="tta-progress-spinner">
               <img class="tta-admin-progress-spinner-svg" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/loading.svg' ); ?>" alt="<?php esc_attr_e( 'Loading…', 'tta' ); ?>" />
             </span>
-            <span class="tta-admin-progress-response"><p class="tta-admin-progress-response-p"></p></span>
+            <span class="tta-admin-progress-response-p"></span>
           </div>
         </div>
       <?php endforeach; ?>

--- a/docs/MemberDashboard.md
+++ b/docs/MemberDashboard.md
@@ -1,6 +1,7 @@
 # Member Dashboard
 
 The Member Dashboard is accessible at `/member-dashboard/` via the shortcode `[tta_member_dashboard]`.
+When a visitor is not logged in, the dashboard still displays all tabs but each one contains a login form with an option to register or become a member.
 It presents five tabs: **Profile Info**, **Your Upcoming Events**, **Your Waitlist Events**, **Your Past Events**, and **Billing & Membership Info**. Tooltip icons now appear before each field label for quicker context. The tooltip text is displayed instantly on hover using visibility toggles instead of opacity fades. The dashboard's JavaScript and CSS are enqueued whenever the page is viewed so tab switching works even when not logged in.
 
 On screens narrower than 1200px the dashboard switches to a mobile-friendly layout. The sidebar tabs become full-width accordion headers; tapping a header expands its section while collapsing the others. Each tab’s form and fields remain intact inside its accordion panel.

--- a/docs/MemberDashboard.md
+++ b/docs/MemberDashboard.md
@@ -48,6 +48,7 @@ Past events show the same details as upcoming events. To keep the database small
 
 - Each attendee entry also lists their final attendance status (Attended, No-Show, or Pending) along with any refund notes.
 - A summary box at the top displays how many events you've attended and no‑showed along with your total savings. The savings amount is wrapped in a `<span class="tta-savings-wow-span">` element so it can be styled prominently. The message varies by membership level—Basic members are prompted to upgrade, Premium members see a referral link, and Free members get an invitation to join.
+- Ticket details remain enclosed within each past event's container so stray markup doesn't spill outside the dashboard layout.
 
 ## Billing & Membership Info
 


### PR DESCRIPTION
## Summary
- Display full dashboard layout to guests and show login/registration form in each tab
- Add login/register handling scripts and styles to member dashboard assets
- Document that dashboard tabs include login forms for unauthenticated visitors

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: Failed opening required '/workspace/trying-to-adult-rva-2025/app/public/wp-content/plugins/tta-management-plugin/tests/../vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_68a2edf28e0883209c50ec6a06bee615