### PR TITLE
Update re-entry checkout messaging and clear session

### DIFF
--- a/app/public/wp-content/plugins/tta-management-plugin/assets/js/frontend/checkout-page.js
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/js/frontend/checkout-page.js
@@ -31,15 +31,19 @@ jQuery(function($){
         if(res.success){
           var html = '';
           if(res.data.membership){
-            var amt = res.data.membership === 'premium' ? 10 : 5;
-            html += '<p>Thanks for becoming a ' + res.data.membership.charAt(0).toUpperCase()+res.data.membership.slice(1) + ' Member! ' +
-              "There's nothing else for you to do - you'll be automatically billed $"+amt+" once monthly, and can cancel anytime on your " +
-              '<a href="https://trying-to-adult-rva-2025.local/member-dashboard/?tab=billing">Member Dashboard</a>. ' +
-              'An email will be sent to ' + tta_checkout.user_email + ' with your Membership Details. Thanks again, and enjoy your Membership perks!</p>';
-            if(res.data.membership === 'basic'){
-              html += '<p>Did you know that there\'s even MORE perks and discounts to be had with a Premium Membership? <a href="https://trying-to-adult-rva-2025.local/become-a-member/">Learn more here.</a></p>';
-            } else if(res.data.membership === 'premium'){
-              html += '<p>Did you know? You can earn a free event and other perks by referring friends and family! Let us know who you\'ve referred at <a href="mailto:sam@tryingtoadultrva.com">sam@tryingtoadultrva.com</a> and we\'ll reach out.</p>';
+            if(res.data.membership === 'reentry'){
+              html += '<p>Thanks for purchasing your Re-Entry Ticket! You can once again register for events. An email will be sent to ' + tta_checkout.user_email + ' for your records. Thanks again, and welcome back!</p>';
+            } else {
+              var amt = res.data.membership === 'premium' ? 10 : 5;
+              html += '<p>Thanks for becoming a ' + res.data.membership.charAt(0).toUpperCase()+res.data.membership.slice(1) + ' Member! ' +
+                "There's nothing else for you to do - you'll be automatically billed $"+amt+" once monthly, and can cancel anytime on your " +
+                '<a href="https://trying-to-adult-rva-2025.local/member-dashboard/?tab=billing">Member Dashboard</a>. ' +
+                'An email will be sent to ' + tta_checkout.user_email + ' with your Membership Details. Thanks again, and enjoy your Membership perks!</p>';
+              if(res.data.membership === 'basic'){
+                html += '<p>Did you know that there\'s even MORE perks and discounts to be had with a Premium Membership? <a href="https://trying-to-adult-rva-2025.local/become-a-member/">Learn more here.</a></p>';
+              } else if(res.data.membership === 'premium'){
+                html += '<p>Did you know? You can earn a free event and other perks by referring friends and family! Let us know who you\'ve referred at <a href="mailto:sam@tryingtoadultrva.com">sam@tryingtoadultrva.com</a> and we\'ll reach out.</p>';
+              }
             }
           }
           if(res.data.has_tickets){

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/templates/checkout-page-template.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/templates/checkout-page-template.php
@@ -15,6 +15,9 @@ $checkout_error = '';
 if ( isset( $_GET['reentry'] ) ) {
     $cart->empty_cart();
     $_SESSION['tta_membership_purchase'] = 'reentry';
+} elseif ( isset( $_SESSION['tta_membership_purchase'] ) && 'reentry' === $_SESSION['tta_membership_purchase'] && 'POST' !== $_SERVER['REQUEST_METHOD'] ) {
+    // Clear any lingering re-entry membership flag when accessing checkout normally.
+    unset( $_SESSION['tta_membership_purchase'] );
 }
 
 if ( 'POST' === $_SERVER['REQUEST_METHOD'] && isset( $_POST['tta_do_checkout'] ) ) {
@@ -207,7 +210,7 @@ if ( $checkout_done ) {
                         '<p>%s</p>',
                         wp_kses_post(
                             sprintf(
-                                __( 'Thanks for purchasing your Re-Entry Ticket! An email will be sent to %s with your purchase details. You\'re now able to purchase event tickets. Thanks again, and welcome back!', 'tta' ),
+                                __( 'Thanks for purchasing your Re-Entry Ticket! You can once again register for events. An email will be sent to %s for your records. Thanks again, and welcome back!', 'tta' ),
                                 esc_html( $user->user_email )
                             )
                         )


### PR DESCRIPTION
## Summary
- show revised wording after purchasing a re-entry ticket and allow event registration again
- clear lingering re-entry membership flag from sessions when visiting checkout normally
- update checkout script to display new re-entry message

## Testing
- `composer install`
- `./vendor/bin/phpunit` *(fails: Failed opening required '/workspace/trying-to-adult-rva-2025/app/public/wp-content/plugins/tta-management-plugin/tests/../vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68a3038833e08320a82f375e0fe34941