### PR TITLE
feat: expand membership tiers and mobile layout

### DIFF
--- a/app/public/wp-content/plugins/tta-management-plugin/assets/css/frontend/style.css
+++ b/app/public/wp-content/plugins/tta-management-plugin/assets/css/frontend/style.css
@@ -87,6 +87,42 @@
   background: #005177;
 }
 
+.tta-membership-mobile {
+  display: none;
+}
+
+.tta-tier-card {
+  border: 1px solid #ccc;
+  margin: 20px 0;
+  padding: 15px;
+}
+
+.tta-tier-card h2 {
+  margin-top: 0;
+  text-align: center;
+}
+
+.tta-tier-card ul {
+  list-style: none;
+  padding: 0;
+}
+
+.tta-tier-card li {
+  display: flex;
+  justify-content: space-between;
+  padding: 5px 0;
+}
+
+@media (max-width: 768px) {
+  .tta-membership-table {
+    display: none;
+  }
+
+  .tta-membership-mobile {
+    display: block;
+  }
+}
+
 
 
 

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/templates/become-member-page-template.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/frontend/templates/become-member-page-template.php
@@ -18,41 +18,79 @@ echo do_shortcode( $header_shortcode );
   <h1><?php esc_html_e( 'Become a Trying to Adult Member', 'tta' ); ?></h1>
   <p><?php esc_html_e( 'Join our community and unlock special perks at local events.', 'tta' ); ?></p>
 
+<?php
+  $tiers = array(
+    'non_member' => __( 'Non-member', 'tta' ),
+    'basic'      => __( 'Standard Member', 'tta' ),
+    'premium'    => __( 'Premium Member', 'tta' ),
+  );
+
+  $features = array(
+    'monthly_cost'            => array(
+      'label'      => __( 'Monthly Cost', 'tta' ),
+      'non_member' => '$0',
+      'basic'      => '$10',
+      'premium'    => '$17',
+    ),
+    'monthly_new_friend_social' => array(
+      'label'      => __( 'Monthly New Friend Social', 'tta' ),
+      'non_member' => __( 'N/A', 'tta' ),
+      'basic'      => __( 'N/A', 'tta' ),
+      'premium'    => __( 'N/A', 'tta' ),
+    ),
+    'classic_events' => array(
+      'label'      => __( '3+ Classic Events Monthly', 'tta' ),
+      'non_member' => '$5 ' . __( 'access pass', 'tta' ),
+      'basic'      => __( 'Free access pass', 'tta' ),
+      'premium'    => __( 'Free access pass', 'tta' ),
+    ),
+    'special_events' => array(
+      'label'      => __( '3+ Special Events Monthly', 'tta' ),
+      'non_member' => '$7 ' . __( 'access pass', 'tta' ),
+      'basic'      => '$5 ' . __( 'access pass', 'tta' ),
+      'premium'    => __( 'Free access pass', 'tta' ),
+    ),
+    'guess_pass' => array(
+      'label'      => __( 'Guest Pass', 'tta' ),
+      'non_member' => __( 'N/A', 'tta' ),
+      'basic'      => __( 'N/A', 'tta' ),
+      'premium'    => __( 'N/A', 'tta' ),
+    ),
+    'waitlist_notice' => array(
+      'label'      => __( 'Advanced Notice on Waitlist Openings', 'tta' ),
+      'non_member' => __( 'N/A', 'tta' ),
+      'basic'      => __( 'N/A', 'tta' ),
+      'premium'    => __( 'N/A', 'tta' ),
+    ),
+    'special_rates' => array(
+      'label'      => __( 'Special Rates for Select Events', 'tta' ),
+      'non_member' => __( 'N/A', 'tta' ),
+      'basic'      => __( 'N/A', 'tta' ),
+      'premium'    => __( 'N/A', 'tta' ),
+    ),
+  );
+?>
+
   <table class="tta-membership-table">
     <thead>
       <tr>
         <th><?php esc_html_e( 'Benefits', 'tta' ); ?></th>
-        <th><?php esc_html_e( 'Basic', 'tta' ); ?></th>
-        <th><?php esc_html_e( 'Premium', 'tta' ); ?></th>
+        <?php foreach ( $tiers as $tier_label ) : ?>
+          <th><?php echo esc_html( $tier_label ); ?></th>
+        <?php endforeach; ?>
       </tr>
     </thead>
     <tbody>
-      <tr>
-        <td><?php esc_html_e( 'Access to free events every month', 'tta' ); ?></td>
-        <td class="check">&#10003;</td>
-        <td class="check">&#10003;</td>
-      </tr>
-      <tr>
-        <td><?php esc_html_e( 'Early access to new events', 'tta' ); ?></td>
-        <td></td>
-        <td class="check">&#10003;</td>
-      </tr>
-      <tr>
-        <td><?php esc_html_e( 'Discounts on paid events', 'tta' ); ?></td>
-        <td></td>
-        <td class="check">&#10003;</td>
-      </tr>
-      <tr>
-        <td><?php esc_html_e( 'Local discounts (coming soon)', 'tta' ); ?></td>
-        <td></td>
-        <td class="check">&#10003;</td>
-      </tr>
-      <tr class="tta-pricing-row">
-        <td><strong><?php esc_html_e( 'Price per month', 'tta' ); ?></strong></td>
-        <td>$5</td>
-        <td>$10</td>
-      </tr>
+      <?php foreach ( $features as $feature ) : ?>
+        <tr>
+          <td><?php echo esc_html( $feature['label'] ); ?></td>
+          <?php foreach ( $tiers as $tier_key => $tier_label ) : ?>
+            <td><?php echo esc_html( $feature[ $tier_key ] ); ?></td>
+          <?php endforeach; ?>
+        </tr>
+      <?php endforeach; ?>
       <tr class="tta-membership-actions">
+        <td></td>
         <td></td>
         <td>
           <button type="button" id="tta-basic-signup" class="tta-button tta-button-primary">
@@ -67,6 +105,31 @@ echo do_shortcode( $header_shortcode );
       </tr>
     </tbody>
   </table>
+
+  <div class="tta-membership-mobile">
+    <?php foreach ( $tiers as $tier_key => $tier_label ) : ?>
+      <div class="tta-tier-card">
+        <h2><?php echo esc_html( $tier_label ); ?></h2>
+        <ul>
+          <?php foreach ( $features as $feature ) : ?>
+            <li>
+              <span class="tta-feature-label"><?php echo esc_html( $feature['label'] ); ?></span>
+              <span class="tta-feature-value"><?php echo esc_html( $feature[ $tier_key ] ); ?></span>
+            </li>
+          <?php endforeach; ?>
+        </ul>
+        <?php if ( 'basic' === $tier_key ) : ?>
+          <button type="button" id="tta-basic-signup" class="tta-button tta-button-primary">
+            <?php esc_html_e( 'Sign Up', 'tta' ); ?>
+          </button>
+        <?php elseif ( 'premium' === $tier_key ) : ?>
+          <button type="button" id="tta-premium-signup" class="tta-button tta-button-primary">
+            <?php esc_html_e( 'Sign Up', 'tta' ); ?>
+          </button>
+        <?php endif; ?>
+      </div>
+    <?php endforeach; ?>
+  </div>
 </div>
 <?php
 get_footer();

--- a/docs/BecomeMemberPage.md
+++ b/docs/BecomeMemberPage.md
@@ -5,14 +5,14 @@ The **Become a Member** template introduces a front‑end landing page for membe
 ## Overview
 - Located at `includes/frontend/templates/become-member-page-template.php`.
 - Registered by `TTA_Become_Member_Page`.
-- Describes Basic vs. Premium benefits in a simple table.
-- Shows pricing ($5 Basic, $10 Premium) in a dedicated row just above the signup buttons.
-- Includes signup buttons embedded within the table. Clicking a button sends an AJAX request that stores the selected membership level in the session and redirects visitors to the cart page.
+- Describes Non-member, Standard Member, and Premium Member benefits in a three-column table with a mobile-friendly card layout.
+- Shows pricing ($0 Non-member, $10 Standard, $17 Premium) in a dedicated row just above the signup buttons.
+- Includes signup buttons for Standard and Premium tiers embedded within the table. Clicking a button sends an AJAX request that stores the selected membership level in the session and redirects visitors to the cart page.
 - The page enqueues `tta-cart.js` so the signup buttons behave like adding tickets to the cart and redirect immediately. The cart will show the chosen membership as a line item so visitors can check out normally.
 - Visitors can complete checkout with just a membership selected—no tickets are required.
-- Only one membership can exist in the cart at a time. Logged-in users who already have a Basic membership cannot add another Basic plan. Premium members cannot add any membership product.
+- Only one membership can exist in the cart at a time. Logged-in users who already have a Standard membership cannot add another Standard plan. Premium members cannot add any membership product.
 - When only a membership is present in the cart, the subtotal and total rows show the price "Per Month" and table columns remain aligned.
-- When tickets are also in the cart, the total row shows the immediate charge followed by the monthly membership amount (e.g. `$15.00 today, $5 Per Month`).
+- When tickets are also in the cart, the total row shows the immediate charge followed by the monthly membership amount (e.g. `$15.00 today, $10 Per Month`).
 
 ### Header
 The template outputs a WPBakery hero row above the content using `do_shortcode()`. The banner displays **Become a Member** over a full-width background image.
@@ -21,4 +21,4 @@ The template outputs a WPBakery hero row above the content using `do_shortcode()
 Membership purchases are handled separately from one‑off ticket sales. The JavaScript on the page calls the `tta_add_membership` AJAX action which stores the chosen level in the visitor's session. Checkout will display this membership in the cart summary and use `TTA_AuthorizeNet_API::create_subscription()` to create a recurring subscription with Authorize.Net.
 The subscription ID returned by the API is stored on the member record for future cancellation and reporting.
 Each subscription uses a consistent name and description depending on the level:
-"Trying to Adult Basic Membership" or "Trying to Adult Premium Membership" with matching descriptions.
+"Trying to Adult Standard Membership" or "Trying to Adult Premium Membership" with matching descriptions.


### PR DESCRIPTION
## Summary
- show membership comparison for Non-member, Standard, and Premium tiers
- add responsive card layout for mobile visitors
- document new membership tiers and responsive layout

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68a365b744c083208891794297c62348