### PR TITLE
Group TTA admin menus before Media

### DIFF
--- a/app/public/wp-content/plugins/tta-management-plugin/trying-to-adult-management-plugin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/trying-to-adult-management-plugin.php
@@ -210,6 +210,9 @@ class TTA_Plugin {
             TTA_Comms_Admin::get_instance();
             TTA_Ads_Admin::get_instance();
             TTA_Refund_Requests_Admin::get_instance();
+
+            add_filter( 'custom_menu_order', '__return_true' );
+            add_filter( 'menu_order', 'tta_group_admin_menu' );
         } else {
             // Frontend shortcodes
             TTA_Events_Shortcode::get_instance();
@@ -232,5 +235,43 @@ class TTA_Plugin {
         // Clear plugin caches after a successful checkout
         add_action( 'tta_checkout_complete', [ 'TTA_Cache', 'flush' ] );
     }
+}
+
+/**
+ * Group all TTA admin pages together above the Media menu item.
+ *
+ * @param string[] $menu_order Original admin menu order.
+ * @return string[] Modified menu order with TTA items grouped.
+ */
+function tta_group_admin_menu( $menu_order ) {
+    if ( ! is_array( $menu_order ) ) {
+        return $menu_order;
+    }
+
+    $tta_items = [
+        'toplevel_page_tta-ads',
+        'toplevel_page_tta-bi-dashboard',
+        'toplevel_page_tta-comms',
+        'toplevel_page_tta-events',
+        'toplevel_page_tta-members',
+        'toplevel_page_tta-refund-requests',
+        'toplevel_page_tta-settings',
+        'toplevel_page_tta-tickets',
+        'toplevel_page_tta-venues',
+        'toplevel_page_tta-discount-codes',
+    ];
+
+    $new_order = [];
+    foreach ( $menu_order as $item ) {
+        if ( 'upload.php' === $item ) {
+            $new_order = array_merge( $new_order, $tta_items );
+        }
+
+        if ( ! in_array( $item, $tta_items, true ) ) {
+            $new_order[] = $item;
+        }
+    }
+
+    return $new_order;
 }
 ?>

--- a/docs/AdminMenu.md
+++ b/docs/AdminMenu.md
@@ -1,0 +1,3 @@
+# Admin Menu
+
+The plugin registers a number of admin pages prefixed with **TTA**. To keep the WordPress dashboard tidy, these pages are automatically grouped together ahead of the core **Media** menu item. This ensures all TTA tools appear consecutively in the sidebar.


### PR DESCRIPTION
## Summary
- Ensure all TTA admin pages are grouped together and appear before WordPress's Media menu item
- Document admin menu organization for TTA tools

## Testing
- `./vendor/bin/phpunit` *(fails: CommsTest syntax error, undefined constant TTA_PLUGIN_DIR, undefined method get_row)*

------
https://chatgpt.com/codex/tasks/task_e_68a368a3a7a083208bbc885030c73d75