### PR TITLE
Group TTA admin menu items

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ messages will not be sent.
 - [Member Dashboard](docs/MemberDashboard.md)
 - [Member History Admin](docs/MemberHistoryAdmin.md)
 - [Admin List Sorting Options](docs/AdminListSorting.md)
+- [Admin Menu Ordering](docs/AdminMenu.md)
 - [Event Metrics Export](docs/EventMetricsExport.md)
 - [Member Metrics Export](docs/MemberMetricsExport.md)
 - [TTA Refund Requests Admin](docs/RefundRequestsAdmin.md)

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-ads-admin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-ads-admin.php
@@ -21,7 +21,7 @@ class TTA_Ads_Admin {
             'tta-ads',
             [ $this, 'render_page' ],
             'dashicons-megaphone',
-            5
+            9
         );
     }
 

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-bi-admin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-bi-admin.php
@@ -17,7 +17,7 @@ class TTA_BI_Admin {
             'tta-bi-dashboard',
             [ $this, 'render_page' ],
             'dashicons-chart-bar',
-            6
+            9.1
         );
     }
     public function render_page() {

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-comms-admin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-comms-admin.php
@@ -13,7 +13,7 @@ class TTA_Comms_Admin {
             'tta-comms',
             [ $this, 'render_page' ],
             'dashicons-email-alt',
-            7
+            9.2
         );
     }
 

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-discount-codes-admin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-discount-codes-admin.php
@@ -22,7 +22,7 @@ class TTA_Discount_Codes_Admin {
             // This icon visually communicates that the screen is for managing codes
             // that apply discounts during checkout.
             'dashicons-tag',
-            14
+            9.9
         );
     }
 

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-events-admin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-events-admin.php
@@ -17,7 +17,7 @@ class TTA_Events_Admin {
             'tta-events',
             [ $this, 'render_page' ],
             'dashicons-calendar',
-            8
+            9.3
         );
     }
 

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-members-admin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-members-admin.php
@@ -21,7 +21,7 @@ class TTA_Members_Admin {
             'tta-members',
             [ $this, 'render_list' ],
             'dashicons-groups',
-            9
+            9.4
         );
     }
 

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-refund-requests-admin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-refund-requests-admin.php
@@ -18,7 +18,7 @@ class TTA_Refund_Requests_Admin {
             'tta-refund-requests',
             [ $this, 'render_page' ],
             'dashicons-money-alt',
-            10
+            9.5
         );
     }
 

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-settings-admin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-settings-admin.php
@@ -21,7 +21,7 @@ class TTA_Settings_Admin {
             'tta-settings',
             [ $this, 'render_page' ],
             'dashicons-admin-generic',
-            11
+            9.6
         );
     }
 

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-tickets-admin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-tickets-admin.php
@@ -13,7 +13,7 @@ class TTA_Tickets_Admin {
             'tta-tickets',
             [ $this, 'render_page' ],
             'dashicons-tickets',
-            12
+            9.7
         );
     }
 

--- a/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-venues-admin.php
+++ b/app/public/wp-content/plugins/tta-management-plugin/includes/admin/class-venues-admin.php
@@ -4,7 +4,7 @@ class TTA_Venues_Admin {
     public static function get_instance(){ static $inst; return $inst ?: $inst = new self(); }
     private function __construct(){ add_action('admin_menu',[ $this,'register_menu' ] ); }
     public function register_menu(){
-        add_menu_page('TTA Venues','TTA Venues','manage_options','tta-venues',[ $this,'render_page' ],'dashicons-location-alt',13);
+        add_menu_page('TTA Venues','TTA Venues','manage_options','tta-venues',[ $this,'render_page' ],'dashicons-location-alt',9.8);
     }
     public function render_page(){
         $tabs = [ 'create'=>'Add Venue','manage'=>'Manage Venues' ];

--- a/docs/AdminMenu.md
+++ b/docs/AdminMenu.md
@@ -1,0 +1,3 @@
+# Admin Menu Ordering
+
+TTA menu items in the WordPress dashboard share contiguous positions so they appear as a single grouped block above the default **Media** item. This keeps all plugin management screens together for easier navigation.


### PR DESCRIPTION
## Summary
- Ensure all TTA plugin admin pages use contiguous menu positions so the Media menu falls after the TTA block
- Document how TTA menu items are grouped in the WordPress dashboard

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68a374f1b81c832080154821294f1892